### PR TITLE
Markdown line offset support

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/formatter/XMLFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/XMLFormatter.java
@@ -112,6 +112,11 @@ public class XMLFormatter extends Formatter {
         Text lineNum = doc.createTextNode(Integer.toString(error.getLineNumber()));
         lineNumberElement.appendChild(lineNum);
 
+        Element sentenceStartOffset = doc.createElement("sentenceStartColumnNum");
+        errorElement.appendChild(sentenceStartOffset);
+        Text offset = doc.createTextNode(Integer.toString(error.getStartColumnNumber()));
+        sentenceStartOffset.appendChild(offset);
+
         Element sentenceElement = doc.createElement("sentence");
         errorElement.appendChild(sentenceElement);
         sentenceElement.appendChild(doc.createTextNode(error.getSentence().content));
@@ -127,5 +132,4 @@ public class XMLFormatter extends Formatter {
         }
         return writer.toString() + "\n";
     }
-
 }

--- a/redpen-core/src/main/java/cc/redpen/model/Section.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Section.java
@@ -180,9 +180,9 @@ public final class Section {
      */
     public Sentence getJoinedHeaderContents() {
         StringBuilder joinedHeader = new StringBuilder();
-        int linePosition = 0;
+        int lineNum = 0;
         if (headerContent.size() > 0) {
-            linePosition = headerContent.get(0).position;
+            lineNum = headerContent.get(0).lineNum;
         }
         int i = 0;
         for (Sentence header : headerContent) {
@@ -193,7 +193,7 @@ public final class Section {
             joinedHeader.append(header.content);
             i++;
         }
-        return new Sentence(joinedHeader.toString(), linePosition);
+        return new Sentence(joinedHeader.toString(), lineNum);
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Sentence block in a Document.
  */
 public final class Sentence implements Serializable {
-    private static final long serialVersionUID = 8001875796889119504L;
+    private static final long serialVersionUID = -3019057510527995111L;
     /**
      * Links (including internal and external ones).
      */
@@ -41,11 +41,14 @@ public final class Sentence implements Serializable {
      */
     public String content;
     /**
+     * Position which the sentence starts with.
+     */
+    public final int startPositionOffset;
+    /**
      * Flag for knowing if the sentence is the first sentence
      * of a block, such as paragraph, list, header.
      */
     public boolean isFirstSentence;
-
     /**
      * A list of tokens.
      *
@@ -57,15 +60,39 @@ public final class Sentence implements Serializable {
      * Constructor.
      *
      * @param sentenceContent  content of sentence
-     * @param sentencePosition sentence position
+     * @param lineNum line number of sentence
      */
-    public Sentence(String sentenceContent, int sentencePosition) {
+    public Sentence(String sentenceContent, int lineNum) {
+        this(sentenceContent, lineNum, 0);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param sentenceContent  content of sentence
+     * @param sentencePosition sentence position
+     * @param startOffset offset of the start position in the line
+     */
+    public Sentence(String sentenceContent, int sentencePosition, int startOffset) {
         super();
         this.content = sentenceContent;
         this.lineNum = sentencePosition;
         this.isFirstSentence = false;
         this.links = new ArrayList<>();
         this.tokens = new ArrayList<>();
+        this.startPositionOffset = startOffset;
+    }
+
+    @Override
+    public String toString() {
+        return "Sentence{" +
+                "links=" + links +
+                ", lineNum=" + lineNum +
+                ", content='" + content + '\'' +
+                ", startPositionOffset=" + startPositionOffset +
+                ", isFirstSentence=" + isFirstSentence +
+                ", tokens=" + tokens +
+                '}';
     }
 
     @Override
@@ -77,6 +104,7 @@ public final class Sentence implements Serializable {
 
         if (isFirstSentence != sentence.isFirstSentence) return false;
         if (lineNum != sentence.lineNum) return false;
+        if (startPositionOffset != sentence.startPositionOffset) return false;
         if (content != null ? !content.equals(sentence.content) : sentence.content != null) return false;
         if (links != null ? !links.equals(sentence.links) : sentence.links != null) return false;
         if (tokens != null ? !tokens.equals(sentence.tokens) : sentence.tokens != null) return false;
@@ -87,21 +115,11 @@ public final class Sentence implements Serializable {
     @Override
     public int hashCode() {
         int result = links != null ? links.hashCode() : 0;
-        result = 31 * result + (content != null ? content.hashCode() : 0);
         result = 31 * result + lineNum;
+        result = 31 * result + (content != null ? content.hashCode() : 0);
+        result = 31 * result + startPositionOffset;
         result = 31 * result + (isFirstSentence ? 1 : 0);
         result = 31 * result + (tokens != null ? tokens.hashCode() : 0);
         return result;
-    }
-
-    @Override
-    public String toString() {
-        return "Sentence{" +
-                "links=" + links +
-                ", content='" + content + '\'' +
-                ", lineNum=" + lineNum +
-                ", isFirstSentence=" + isFirstSentence +
-                ", tokens=" + tokens +
-                '}';
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -35,7 +35,7 @@ public final class Sentence implements Serializable {
     /**
      * Sentence position in a file.
      */
-    public final int position;
+    public final int lineNum;
     /**
      * Content of string.
      */
@@ -62,7 +62,7 @@ public final class Sentence implements Serializable {
     public Sentence(String sentenceContent, int sentencePosition) {
         super();
         this.content = sentenceContent;
-        this.position = sentencePosition;
+        this.lineNum = sentencePosition;
         this.isFirstSentence = false;
         this.links = new ArrayList<>();
         this.tokens = new ArrayList<>();
@@ -76,7 +76,7 @@ public final class Sentence implements Serializable {
         Sentence sentence = (Sentence) o;
 
         if (isFirstSentence != sentence.isFirstSentence) return false;
-        if (position != sentence.position) return false;
+        if (lineNum != sentence.lineNum) return false;
         if (content != null ? !content.equals(sentence.content) : sentence.content != null) return false;
         if (links != null ? !links.equals(sentence.links) : sentence.links != null) return false;
         if (tokens != null ? !tokens.equals(sentence.tokens) : sentence.tokens != null) return false;
@@ -88,7 +88,7 @@ public final class Sentence implements Serializable {
     public int hashCode() {
         int result = links != null ? links.hashCode() : 0;
         result = 31 * result + (content != null ? content.hashCode() : 0);
-        result = 31 * result + position;
+        result = 31 * result + lineNum;
         result = 31 * result + (isFirstSentence ? 1 : 0);
         result = 31 * result + (tokens != null ? tokens.hashCode() : 0);
         return result;
@@ -99,7 +99,7 @@ public final class Sentence implements Serializable {
         return "Sentence{" +
                 "links=" + links +
                 ", content='" + content + '\'' +
-                ", position=" + position +
+                ", lineNum=" + lineNum +
                 ", isFirstSentence=" + isFirstSentence +
                 ", tokens=" + tokens +
                 '}';

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -17,6 +17,7 @@
  */
 package cc.redpen.model;
 
+import cc.redpen.parser.LineOffset;
 import cc.redpen.tokenizer.TokenElement;
 
 import java.io.Serializable;
@@ -57,6 +58,11 @@ public final class Sentence implements Serializable {
     public List<TokenElement> tokens;
 
     /**
+     * Combinations of line Number and the position offset
+     */
+    public List<LineOffset> offsetMap;
+
+    /**
      * Constructor.
      *
      * @param sentenceContent  content of sentence
@@ -92,6 +98,7 @@ public final class Sentence implements Serializable {
                 ", startPositionOffset=" + startPositionOffset +
                 ", isFirstSentence=" + isFirstSentence +
                 ", tokens=" + tokens +
+                ", offsetMap=" + offsetMap +
                 '}';
     }
 

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -35,7 +35,7 @@ public final class Sentence implements Serializable {
     /**
      * Sentence position in a file.
      */
-    public final int lineNum;
+    public int lineNum;
     /**
      * Content of string.
      */
@@ -43,7 +43,7 @@ public final class Sentence implements Serializable {
     /**
      * Position which the sentence starts with.
      */
-    public final int startPositionOffset;
+    public int startPositionOffset;
     /**
      * Flag for knowing if the sentence is the first sentence
      * of a block, such as paragraph, list, header.

--- a/redpen-core/src/main/java/cc/redpen/parser/LineOffset.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/LineOffset.java
@@ -1,3 +1,20 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package cc.redpen.parser;
 
 final public class LineOffset implements Comparable {

--- a/redpen-core/src/main/java/cc/redpen/parser/LineOffset.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/LineOffset.java
@@ -1,0 +1,49 @@
+package cc.redpen.parser;
+
+final public class LineOffset implements Comparable {
+    public int lineNum;
+    public int offset;
+
+    public LineOffset(int lineNum, int offset) {
+        this.lineNum = lineNum;
+        this.offset = offset;
+    }
+
+    @Override
+    public String toString() {
+        return "LineOffset{" +
+                "lineNum=" + lineNum +
+                ", offset=" + offset +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LineOffset that = (LineOffset) o;
+
+        if (lineNum != that.lineNum) return false;
+        if (offset != that.offset) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = lineNum;
+        result = 31 * result + offset;
+        return result;
+    }
+
+
+    @Override
+    public int compareTo(Object o) {
+        LineOffset that = (LineOffset) o;
+        if (this.lineNum != that.lineNum) {
+            return this.lineNum - that.lineNum;
+        }
+        return this.offset - that.offset;
+    }
+}

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -143,8 +143,8 @@ public final class SentenceExtractor {
      * @param lineStartOffset position offset
      * @return remaining line
      */
-    public String extract(String line, List<Sentence> outputSentences, int lineNum,
-            Integer lineStartOffset) {
+    public String extract(String line, List<Sentence> outputSentences,
+            int lineNum, Integer lineStartOffset) {
         int periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
         if (periodPosition == -1) {
             return line;
@@ -153,8 +153,8 @@ public final class SentenceExtractor {
                 Sentence sentence = new Sentence(line.substring(0,
                         periodPosition + 1), lineNum, lineStartOffset);
                 outputSentences.add(sentence);
-                lineStartOffset += periodPosition;
-                line = line.substring(periodPosition + 1,line.length());
+                lineStartOffset = periodPosition + 1;
+                line = line.substring(periodPosition + 1, line.length());
                 periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
                 if (periodPosition == -1) {
                     return line;

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -140,25 +140,39 @@ public final class SentenceExtractor {
      * @param line            Input line which can contain more than one sentences
      * @param outputSentences List of extracted sentences
      * @param lineNum         Line number
+     * @param lineStartOffset position offset
      * @return remaining line
      */
-    public String extract(String line, List<Sentence> outputSentences, int lineNum) {
+    public String extract(String line, List<Sentence> outputSentences, int lineNum,
+            Integer lineStartOffset) {
         int periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
         if (periodPosition == -1) {
             return line;
         } else {
             while (true) {
                 Sentence sentence = new Sentence(line.substring(0,
-                        periodPosition + 1), lineNum);
+                        periodPosition + 1), lineNum, lineStartOffset);
                 outputSentences.add(sentence);
-                line = line.substring(periodPosition + 1,
-                        line.length());
+                lineStartOffset += periodPosition;
+                line = line.substring(periodPosition + 1,line.length());
                 periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
                 if (periodPosition == -1) {
                     return line;
                 }
             }
         }
+    }
+
+    /**
+     * Get Sentence lists.
+     *
+     * @param line            Input line which can contain more than one sentences
+     * @param outputSentences List of extracted sentences
+     * @param lineNum         Line number
+     * @return remaining line
+     */
+    public String extract(String line, List<Sentence> outputSentences, int lineNum) {
+        return extract(line, outputSentences, lineNum, 0);
     }
 
     /**
@@ -189,4 +203,5 @@ public final class SentenceExtractor {
         generateSimplePattern(this.fullStopList, patternString);
         return Pattern.compile(patternString.toString());
     }
+
 }

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -140,20 +140,17 @@ public final class SentenceExtractor {
      * @param line            Input line which can contain more than one sentences
      * @param outputSentences List of extracted sentences
      * @param lineNum         Line number
-     * @param lineStartOffset position offset
      * @return remaining line
      */
-    public String extract(String line, List<Sentence> outputSentences,
-            int lineNum, Integer lineStartOffset) {
+    public String extract(String line, List<Sentence> outputSentences, int lineNum) {
         int periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
         if (periodPosition == -1) {
             return line;
         } else {
             while (true) {
                 Sentence sentence = new Sentence(line.substring(0,
-                        periodPosition + 1), lineNum, lineStartOffset);
+                        periodPosition + 1), lineNum);
                 outputSentences.add(sentence);
-                lineStartOffset = periodPosition + 1;
                 line = line.substring(periodPosition + 1, line.length());
                 periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
                 if (periodPosition == -1) {
@@ -161,18 +158,6 @@ public final class SentenceExtractor {
                 }
             }
         }
-    }
-
-    /**
-     * Get Sentence lists.
-     *
-     * @param line            Input line which can contain more than one sentences
-     * @param outputSentences List of extracted sentences
-     * @param lineNum         Line number
-     * @return remaining line
-     */
-    public String extract(String line, List<Sentence> outputSentences, int lineNum) {
-        return extract(line, outputSentences, lineNum, 0);
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -137,19 +137,19 @@ public final class SentenceExtractor {
     /**
      * Get Sentence lists.
      *
-     * @param line            input line which can contain more than one sentences
+     * @param line            Input line which can contain more than one sentences
      * @param outputSentences List of extracted sentences
-     * @param position        line number
+     * @param lineNum         Line number
      * @return remaining line
      */
-    public String extract(String line, List<Sentence> outputSentences, int position) {
+    public String extract(String line, List<Sentence> outputSentences, int lineNum) {
         int periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
         if (periodPosition == -1) {
             return line;
         } else {
             while (true) {
                 Sentence sentence = new Sentence(line.substring(0,
-                        periodPosition + 1), position);
+                        periodPosition + 1), lineNum);
                 outputSentences.add(sentence);
                 line = line.substring(periodPosition + 1,
                         line.length());

--- a/redpen-core/src/main/java/cc/redpen/parser/WikiParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/WikiParser.java
@@ -228,7 +228,7 @@ final class WikiParser extends BaseDocumentParser {
                 if (tagInternal.length > 2) {
                     LOG.warn(
                             "Invalid link block: there are more than two link blocks at line "
-                                    + sentence.position);
+                                    + sentence.lineNum);
                 }
                 tagURL = tagInternal[1].trim();
                 StringBuilder buffer = new StringBuilder();

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -70,6 +70,7 @@ final class CandidateSentence {
                 + "lineNum=" + lineNum
                 + ", sentence='" + sentence + '\''
                 + ", link='" + link + '\''
+                + ", startPositionOffset='" + startPositionOffset + '\''
                 + '}';
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -23,9 +23,9 @@ import java.util.List;
 /**
  * Buffer list of to candidate sentence.
  */
-final class CandidateSentence {
+final public class CandidateSentence {
 
-    class LineOffset {
+    final static public class LineOffset {
         public int lineNum;
         public int offset;
 
@@ -68,6 +68,10 @@ final class CandidateSentence {
         for (int i = 0; i < sentence.length(); ++i) {
             offsetMap.add(new LineOffset(lineNum, positionOffset+i));
         }
+    }
+
+    public List<LineOffset> getOffsetMap() {
+        return offsetMap;
     }
 
     public int getLineNum() {

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -49,7 +49,7 @@ final public class CandidateSentence {
         this.link = link;
         this.startPositionOffset = positionOffset;
         this.offsetMap = new ArrayList<>();
-        for (int i = 0; i < sentence.length(); ++i) {
+        for (int i = 0; i < sentence.length(); i++) {
             offsetMap.add(new LineOffset(lineNum, positionOffset+i));
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -27,16 +27,26 @@ final class CandidateSentence {
 
     private String link;
 
-    CandidateSentence(int line,
-                      String lineCharacter, String linkCharacter) {
-        this.lineNum = line;
-        this.sentence = lineCharacter;
-        this.link = linkCharacter;
+    private int startPositionOffset;
+
+    CandidateSentence(int lineNum,
+                      String content, String link) {
+        this(lineNum, content, link, 0);
+    }
+
+    CandidateSentence(int lineNum, String sentence, String link,
+            int positionOffset) {
+        this.lineNum = lineNum;
+        this.sentence = sentence;
+        this.link = link;
+        this.startPositionOffset = positionOffset;
     }
 
     public int getLineNum() {
         return lineNum;
     }
+
+    public int getStartPositionOffset() { return startPositionOffset; }
 
     public String getSentence() {
         return sentence;

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -23,13 +23,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Buffer list of to candidate sentence.
+ * Buffer list of to candidate content.
  */
 final public class CandidateSentence {
 
     private int lineNum;
 
-    private String sentence;
+    private String content;
 
     private String link;
 
@@ -42,14 +42,14 @@ final public class CandidateSentence {
         this(lineNum, content, link, 0);
     }
 
-    CandidateSentence(int lineNum, String sentence, String link,
+    CandidateSentence(int lineNum, String content, String link,
             int positionOffset) {
         this.lineNum = lineNum;
-        this.sentence = sentence;
+        this.content = content;
         this.link = link;
         this.startPositionOffset = positionOffset;
         this.offsetMap = new ArrayList<>();
-        for (int i = 0; i < sentence.length(); i++) {
+        for (int i = 0; i < content.length(); i++) {
             offsetMap.add(new LineOffset(lineNum, positionOffset+i));
         }
     }
@@ -64,12 +64,12 @@ final public class CandidateSentence {
 
     public int getStartPositionOffset() { return startPositionOffset; }
 
-    public String getSentence() {
-        return sentence;
+    public String getContent() {
+        return content;
     }
 
-    public void setSentence(String text) {
-        this.sentence = text;
+    public void setContent(String text) {
+        this.content = text;
     }
 
     public String getLink() {
@@ -84,7 +84,7 @@ final public class CandidateSentence {
     public String toString() {
         return "CandidateSentence{" +
                 "lineNum=" + lineNum +
-                ", sentence='" + sentence + '\'' +
+                ", content='" + content + '\'' +
                 ", link='" + link + '\'' +
                 ", startPositionOffset=" + startPositionOffset +
                 ", offsetMap=" + offsetMap +

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -17,6 +17,8 @@
  */
 package cc.redpen.parser.markdown;
 
+import cc.redpen.parser.LineOffset;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,24 +26,6 @@ import java.util.List;
  * Buffer list of to candidate sentence.
  */
 final public class CandidateSentence {
-
-    final static public class LineOffset {
-        public int lineNum;
-        public int offset;
-
-        public LineOffset(int lineNum, int offset) {
-            this.lineNum = lineNum;
-            this.offset = offset;
-        }
-
-        @Override
-        public String toString() {
-            return "LineOffset{" +
-                    "lineNum=" + lineNum +
-                    ", offset=" + offset +
-                    '}';
-        }
-    }
 
     private int lineNum;
 

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/CandidateSentence.java
@@ -17,10 +17,32 @@
  */
 package cc.redpen.parser.markdown;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Buffer list of to candidate sentence.
  */
 final class CandidateSentence {
+
+    class LineOffset {
+        public int lineNum;
+        public int offset;
+
+        public LineOffset(int lineNum, int offset) {
+            this.lineNum = lineNum;
+            this.offset = offset;
+        }
+
+        @Override
+        public String toString() {
+            return "LineOffset{" +
+                    "lineNum=" + lineNum +
+                    ", offset=" + offset +
+                    '}';
+        }
+    }
+
     private int lineNum;
 
     private String sentence;
@@ -28,6 +50,8 @@ final class CandidateSentence {
     private String link;
 
     private int startPositionOffset;
+
+    private List<LineOffset> offsetMap;
 
     CandidateSentence(int lineNum,
                       String content, String link) {
@@ -40,6 +64,10 @@ final class CandidateSentence {
         this.sentence = sentence;
         this.link = link;
         this.startPositionOffset = positionOffset;
+        this.offsetMap = new ArrayList<>();
+        for (int i = 0; i < sentence.length(); ++i) {
+            offsetMap.add(new LineOffset(lineNum, positionOffset+i));
+        }
     }
 
     public int getLineNum() {
@@ -66,11 +94,12 @@ final class CandidateSentence {
 
     @Override
     public String toString() {
-        return "CandidateSentence{"
-                + "lineNum=" + lineNum
-                + ", sentence='" + sentence + '\''
-                + ", link='" + link + '\''
-                + ", startPositionOffset='" + startPositionOffset + '\''
-                + '}';
+        return "CandidateSentence{" +
+                "lineNum=" + lineNum +
+                ", sentence='" + sentence + '\'' +
+                ", link='" + link + '\'' +
+                ", startPositionOffset=" + startPositionOffset +
+                ", offsetMap=" + offsetMap +
+                '}';
     }
 }

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
@@ -32,13 +32,6 @@ public class MergedCandidateSentence {
         List<LineOffset> offsetMap = new ArrayList<>();
 
         for (CandidateSentence sentence : candidateSentences) {
-            if (offsetMap.size() > 0) {
-                int rt = sentence.getLineNum() - offsetMap.get(offsetMap.size() - 1).lineNum;
-                for (int i = 0; i < rt; i++) {
-                    contents.append(" ");
-                    offsetMap.add(new LineOffset(sentence.getLineNum() + i, 0));
-                }
-            }
             contents.append(sentence.getContent());
             offsetMap.addAll(sentence.getOffsetMap());
             if (sentence.getLink() != null) {

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
@@ -30,11 +30,8 @@ public class MergedCandidateSentence {
             return null;
         }
         int lineNum = candidateSentences.get(0).getLineNum();
-
         StringBuilder contents = new StringBuilder();
-
         Map<LineOffset, String> links = new HashMap<>();
-
         List<LineOffset> offsetMap = new ArrayList<>();
 
         for (CandidateSentence sentence : candidateSentences) {
@@ -45,7 +42,7 @@ public class MergedCandidateSentence {
                     offsetMap.add(new LineOffset(sentence.getLineNum() + i, 0));
                 }
             }
-            contents.append(sentence.getSentence());
+            contents.append(sentence.getContent());
             offsetMap.addAll(sentence.getOffsetMap());
             if (sentence.getLink() != null) {
                 links.put(sentence.getOffsetMap().get(0), sentence.getLink());
@@ -67,7 +64,6 @@ public class MergedCandidateSentence {
     }
 
     public int getLineNum() {
-
         return lineNum;
     }
 

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
@@ -1,0 +1,79 @@
+package cc.redpen.parser.markdown;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MergedCandidateSentence {
+
+    private int lineNum;
+
+    private String contents;
+
+    private List<String> links; // candidateSentenceId -> link
+
+    private List<CandidateSentence.LineOffset> offsetMap;
+
+    public MergedCandidateSentence(int lineNum, String contents,
+            List<String> links, List<CandidateSentence.LineOffset> offsetMap) {
+        this.lineNum = lineNum;
+        this.contents = contents;
+        this.links = links;
+        this.offsetMap = offsetMap;
+    }
+
+    public static MergedCandidateSentence merge(List<CandidateSentence> candidateSentences) {
+        if (candidateSentences.size() == 0) {
+            return null;
+        }
+        int lineNum = candidateSentences.get(0).getLineNum();
+
+        StringBuilder contents = new StringBuilder();
+
+        List<String> links = new ArrayList<>(); // candidateSentenceId -> link
+
+        List<CandidateSentence.LineOffset> offsetMap = new ArrayList<>();
+
+        for (CandidateSentence sentence : candidateSentences) {
+            if (offsetMap.size() > 0) {
+                int rt = sentence.getLineNum() - offsetMap.get(offsetMap.size() - 1).lineNum;
+                for (int i = 0; i < rt; i++) {
+                    contents.append(" ");
+                    offsetMap.add(new CandidateSentence.LineOffset(sentence.getLineNum() + i, 0));
+                }
+            }
+            contents.append(sentence.getSentence());
+            offsetMap.addAll(sentence.getOffsetMap());
+            if (sentence.getLink() != null) {
+                links.add(sentence.getLink());
+            }
+        }
+        return new MergedCandidateSentence(lineNum, contents.toString(), links, offsetMap);
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public List<String> getLinks() {
+        return links;
+    }
+
+    public List<CandidateSentence.LineOffset> getOffsetMap() {
+        return offsetMap;
+    }
+
+    public int getLineNum() {
+
+        return lineNum;
+    }
+
+    @Override
+    public String toString() {
+        return "MergedCandidateSentence{" +
+                "lineNum=" + lineNum +
+                ", contents='" + contents + '\'' +
+                ", links=" + links +
+                ", offsetMap=" + offsetMap +
+                '}';
+    }
+}

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
@@ -1,7 +1,11 @@
 package cc.redpen.parser.markdown;
 
+import cc.redpen.parser.LineOffset;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class MergedCandidateSentence {
 
@@ -9,12 +13,12 @@ public class MergedCandidateSentence {
 
     private String contents;
 
-    private List<String> links; // candidateSentenceId -> link
+    private Map<LineOffset, String> links;
 
-    private List<CandidateSentence.LineOffset> offsetMap;
+    private List<LineOffset> offsetMap;
 
     public MergedCandidateSentence(int lineNum, String contents,
-            List<String> links, List<CandidateSentence.LineOffset> offsetMap) {
+            Map<LineOffset, String> links, List<LineOffset> offsetMap) {
         this.lineNum = lineNum;
         this.contents = contents;
         this.links = links;
@@ -29,22 +33,22 @@ public class MergedCandidateSentence {
 
         StringBuilder contents = new StringBuilder();
 
-        List<String> links = new ArrayList<>(); // candidateSentenceId -> link
+        Map<LineOffset, String> links = new HashMap<>();
 
-        List<CandidateSentence.LineOffset> offsetMap = new ArrayList<>();
+        List<LineOffset> offsetMap = new ArrayList<>();
 
         for (CandidateSentence sentence : candidateSentences) {
             if (offsetMap.size() > 0) {
                 int rt = sentence.getLineNum() - offsetMap.get(offsetMap.size() - 1).lineNum;
                 for (int i = 0; i < rt; i++) {
                     contents.append(" ");
-                    offsetMap.add(new CandidateSentence.LineOffset(sentence.getLineNum() + i, 0));
+                    offsetMap.add(new LineOffset(sentence.getLineNum() + i, 0));
                 }
             }
             contents.append(sentence.getSentence());
             offsetMap.addAll(sentence.getOffsetMap());
             if (sentence.getLink() != null) {
-                links.add(sentence.getLink());
+                links.put(sentence.getOffsetMap().get(0), sentence.getLink());
             }
         }
         return new MergedCandidateSentence(lineNum, contents.toString(), links, offsetMap);
@@ -54,11 +58,11 @@ public class MergedCandidateSentence {
         return contents;
     }
 
-    public List<String> getLinks() {
+    public Map<LineOffset, String> getLinks() {
         return links;
     }
 
-    public List<CandidateSentence.LineOffset> getOffsetMap() {
+    public List<LineOffset> getOffsetMap() {
         return offsetMap;
     }
 

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/MergedCandidateSentence.java
@@ -2,10 +2,7 @@ package cc.redpen.parser.markdown;
 
 import cc.redpen.parser.LineOffset;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MergedCandidateSentence {
 
@@ -25,9 +22,9 @@ public class MergedCandidateSentence {
         this.offsetMap = offsetMap;
     }
 
-    public static MergedCandidateSentence merge(List<CandidateSentence> candidateSentences) {
+    public static Optional<MergedCandidateSentence> merge(List<CandidateSentence> candidateSentences) {
         if (candidateSentences.size() == 0) {
-            return null;
+            return Optional.empty();
         }
         int lineNum = candidateSentences.get(0).getLineNum();
         StringBuilder contents = new StringBuilder();
@@ -48,7 +45,7 @@ public class MergedCandidateSentence {
                 links.put(sentence.getOffsetMap().get(0), sentence.getLink());
             }
         }
-        return new MergedCandidateSentence(lineNum, contents.toString(), links, offsetMap);
+        return Optional.of(new MergedCandidateSentence(lineNum, contents.toString(), links, offsetMap));
     }
 
     public String getContents() {

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -140,16 +140,18 @@ public class ToFileContentSerializer implements Visitor {
 
     private List<Sentence> createSentenceList() {
         List<Sentence> outputSentences = new ArrayList<>();
-        MergedCandidateSentence mergedCandidateSentence = MergedCandidateSentence.merge(candidateSentences);
-        if (mergedCandidateSentence != null) {
-            outputSentences = extractSentences(mergedCandidateSentence);
-        }
+        Optional<MergedCandidateSentence> mergedCandidateSentence =
+                MergedCandidateSentence.merge(candidateSentences);
+        mergedCandidateSentence.ifPresent(m ->
+            extractSentences(m, outputSentences)
+        );
         candidateSentences.clear();
         return outputSentences;
     }
 
-    private List<Sentence> extractSentences(MergedCandidateSentence mergedCandidateSentence) {
-        List<Sentence> outputSentences = new ArrayList<>();
+    private List<Sentence> extractSentences(MergedCandidateSentence mergedCandidateSentence,
+            List<Sentence> outputSentences) {
+        // TODO refactoring extract just extract sentence start and end position list
         String remainStr = sentenceExtractor.extract(mergedCandidateSentence.getContents(),
                 outputSentences, mergedCandidateSentence.getLineNum());
 

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -155,6 +155,7 @@ public class ToFileContentSerializer implements Visitor {
             if (lineStartOffset < 0) {
                 lineStartOffset = candidateSentence.getStartPositionOffset();
             }
+
             // extract sentences in input line
             List<Sentence> currentSentences = new ArrayList<>();
             remainStr = extractSentences(remainStr, lineNum, candidateSentence,
@@ -190,10 +191,10 @@ public class ToFileContentSerializer implements Visitor {
 
     private String extractSentences(String remainStr,
             int lineNum, CandidateSentence candidateSentence,
-            List<Sentence> currentSentences, Integer lineStartOffset) {
+            List<Sentence> outputSentences, Integer lineStartOffset) {
         remainStr = sentenceExtractor.extract(
                 remainStr + candidateSentence.getSentence(),
-                currentSentences, lineNum, lineStartOffset);
+                outputSentences, lineNum, lineStartOffset);
         return remainStr;
     }
 

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -341,7 +341,9 @@ public class ToFileContentSerializer implements Visitor {
 
         switch (simpleNode.getType()) {
             case Linebreak:
-                break;
+                addCandidateSentence(
+                        getLineNumberFromStartIndex(simpleNode.getStartIndex()),
+                        " ", simpleNode.getStartIndex() - getLineStartIndex(lineNumber));
             case Nbsp:
                 break;
             case HRule:

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -8,7 +8,7 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, sofftware
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -173,7 +173,7 @@ public class ToFileContentSerializer implements Visitor {
             for (LineOffset linkPosition : linkPositions) {
                 if (linkPosition.compareTo(outputSentence.offsetMap.get(0)) >= 0
                         && linkPosition.compareTo(outputSentence.offsetMap.get(
-                        outputSentence.content.length() - 2)) <= 0) { // TODO: safer
+                        getEndIndex(outputSentence))) <= 0) {
                     outputSentence.links.add(mergedCandidateSentence.getLinks().get(linkPosition));
                 }
 
@@ -181,6 +181,18 @@ public class ToFileContentSerializer implements Visitor {
             offset += outputSentence.content.length();
         }
         return outputSentences;
+    }
+
+    private int getEndIndex(Sentence outputSentence) {
+        System.out.println("sentence: " + outputSentence.content);
+        System.out.println("content.size: " + outputSentence.content.length());
+        System.out.println("offsetMap.size: " + outputSentence.offsetMap.size());
+
+        if (outputSentence.content.length() > outputSentence.offsetMap.size() - 1) {
+            return outputSentence.offsetMap.size() - 1;
+        } else {
+            return outputSentence.content.length() - 1;
+        }
     }
 
     //FIXME wikiparser have same method. pull up or expand to utils

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -167,13 +167,13 @@ public class ToFileContentSerializer implements Visitor {
             outputSentence.startPositionOffset = mergedCandidateSentence.getOffsetMap().get(offset).offset;
             outputSentence.lineNum = mergedCandidateSentence.getOffsetMap().get(offset).lineNum;
             outputSentence.offsetMap = mergedCandidateSentence.getOffsetMap().subList(offset,
-                    offset + outputSentence.content.length()-1);
+                    offset + outputSentence.content.length());
 
             Set<LineOffset> linkPositions = mergedCandidateSentence.getLinks().keySet();
             for (LineOffset linkPosition : linkPositions) {
                 if (linkPosition.compareTo(outputSentence.offsetMap.get(0)) >= 0
                         && linkPosition.compareTo(outputSentence.offsetMap.get(
-                        getEndIndex(outputSentence))) <= 0) {
+                        outputSentence.content.length() - 1)) <= 0) {
                     outputSentence.links.add(mergedCandidateSentence.getLinks().get(linkPosition));
                 }
 
@@ -181,18 +181,6 @@ public class ToFileContentSerializer implements Visitor {
             offset += outputSentence.content.length();
         }
         return outputSentences;
-    }
-
-    private int getEndIndex(Sentence outputSentence) {
-        System.out.println("sentence: " + outputSentence.content);
-        System.out.println("content.size: " + outputSentence.content.length());
-        System.out.println("offsetMap.size: " + outputSentence.offsetMap.size());
-
-        if (outputSentence.content.length() > outputSentence.offsetMap.size() - 1) {
-            return outputSentence.offsetMap.size() - 1;
-        } else {
-            return outputSentence.content.length() - 1;
-        }
     }
 
     //FIXME wikiparser have same method. pull up or expand to utils

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -8,7 +8,7 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, sofftware
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
@@ -146,16 +146,18 @@ public class ToFileContentSerializer implements Visitor {
         Sentence currentSentence = null;
         List<String> remainLinks = new ArrayList<>();
         int lineNum = -1;
-        Integer lineStartOffset = 0;
+        Integer lineStartOffset = -1;
 
         for (CandidateSentence candidateSentence : candidateSentences) {
-            lineNum = candidateSentence.getLineNum();
+            if (lineNum < 0) {
+                lineNum = candidateSentence.getLineNum();
+            }
             if (lineStartOffset < 0) {
                 lineStartOffset = candidateSentence.getStartPositionOffset();
             }
             // extract sentences in input line
             List<Sentence> currentSentences = new ArrayList<>();
-            remainStr = extractSentences(remainStr, candidateSentence,
+            remainStr = extractSentences(remainStr, lineNum, candidateSentence,
                     currentSentences, lineStartOffset);
 
             if (remainStr.length() == 0) {
@@ -179,18 +181,19 @@ public class ToFileContentSerializer implements Visitor {
         }
         // for remaining
         if (remainStr.length() > 0) {
-            newSentences.add(new Sentence(remainStr, lineNum));
+            newSentences.add(new Sentence(remainStr, lineNum, lineStartOffset));
         }
+
         candidateSentences.clear();
         return newSentences;
     }
 
     private String extractSentences(String remainStr,
-            CandidateSentence candidateSentence,
+            int lineNum, CandidateSentence candidateSentence,
             List<Sentence> currentSentences, Integer lineStartOffset) {
         remainStr = sentenceExtractor.extract(
                 remainStr + candidateSentence.getSentence(),
-                currentSentences, candidateSentence.getLineNum(), lineStartOffset);
+                currentSentences, lineNum, lineStartOffset);
         return remainStr;
     }
 

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -431,8 +431,8 @@ public class ToFileContentSerializer implements Visitor {
         if (StringUtils.isNotEmpty(url)) {
             lastCandidateSentence.setLink(url);
         } else {
-            lastCandidateSentence.setSentence(
-                    lastCandidateSentence.getSentence());
+            lastCandidateSentence.setContent(
+                    lastCandidateSentence.getContent());
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidationError.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidationError.java
@@ -63,6 +63,15 @@ public final class ValidationError implements java.io.Serializable {
     }
 
     /**
+     * Get column number in which the error occurs.
+     *
+     * @return column (character) position which sentence starts
+     */
+    public int getStartColumnNumber() {
+        return sentence.startPositionOffset;
+    }
+
+    /**
      * Get sentence containing the error.
      *
      * @return sentence

--- a/redpen-core/src/main/java/cc/redpen/validator/ValidationError.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/ValidationError.java
@@ -50,7 +50,7 @@ public final class ValidationError implements java.io.Serializable {
      * @return the number of line
      */
     public int getLineNumber() {
-        return sentence.position;
+        return sentence.lineNum;
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/validator/section/DuplicatedSectionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/section/DuplicatedSectionValidator.java
@@ -62,7 +62,7 @@ final public class DuplicatedSectionValidator extends Validator {
                     calcCosine(targetVector, candidateVector) > threhold) {
                 Optional<Sentence> header = Optional.ofNullable(section.getHeaderContent(0));
                 errors.add(createValidationError(header.orElse(section.getParagraph(0).getSentence(0)),
-                        sectionVector.header.position));
+                        sectionVector.header.lineNum));
             }
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaSpellCheckValidator.java
@@ -112,7 +112,7 @@ final public class KatakanaSpellCheckValidator extends Validator {
             }
         }
         if (!found) {
-            dic.put(katakana, sentence.position);
+            dic.put(katakana, sentence.lineNum);
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidator.java
@@ -34,7 +34,7 @@ final public class SpaceBeginningOfSentenceValidator extends Validator {
     private Map<Integer, List<Sentence>> sentencePositions = new HashMap<>();
 
     private boolean isFistInLine(Sentence sentence) {
-        return sentence.isFirstSentence || sentencePositions.get(sentence.position).get(0) == sentence;
+        return sentence.isFirstSentence || sentencePositions.get(sentence.lineNum).get(0) == sentence;
     }
 
     @Override
@@ -47,10 +47,10 @@ final public class SpaceBeginningOfSentenceValidator extends Validator {
 
     @Override
     public void preValidate(Sentence sentence) {
-        if (!sentencePositions.containsKey(sentence.position)) {
-            sentencePositions.put(sentence.position, new LinkedList<>());
+        if (!sentencePositions.containsKey(sentence.lineNum)) {
+            sentencePositions.put(sentence.lineNum, new LinkedList<>());
         }
-        List<Sentence> list = sentencePositions.get(sentence.position);
+        List<Sentence> list = sentencePositions.get(sentence.lineNum);
         list.add(sentence);
     }
 

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -167,16 +167,23 @@ public class MarkdownParserTest {
     public void testGenerateDocumentWithMultipleSentenceInOneSentence() {
         String sampleText =
                 "Tokyu is a good railway company. The company is reliable. In addition it is rich.";
-        String[] expectedResult = {"Tokyu is a good railway company.",
-                " The company is reliable.", " In addition it is rich."};
+
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
         assertEquals(3, firstParagraph.getNumberOfSentences());
-        for (int i = 0; i < expectedResult.length; i++) {
-            assertEquals(expectedResult[i], firstParagraph.getSentence(i).content);
-            assertEquals(1, firstParagraph.getSentence(i).lineNum);
-        }
+
+        assertEquals("Tokyu is a good railway company.", firstParagraph.getSentence(0).content);
+        assertEquals(1, firstParagraph.getSentence(0).lineNum);
+        assertEquals(0, firstParagraph.getSentence(0).startPositionOffset);
+
+        assertEquals(" The company is reliable.", firstParagraph.getSentence(1).content);
+        assertEquals(1, firstParagraph.getSentence(1).lineNum);
+        assertEquals(32, firstParagraph.getSentence(1).startPositionOffset);
+
+        assertEquals(" In addition it is rich.", firstParagraph.getSentence(2).content);
+        assertEquals(1, firstParagraph.getSentence(2).lineNum);
+        assertEquals(57, firstParagraph.getSentence(2).startPositionOffset);
     }
 
     @Test
@@ -186,12 +193,18 @@ public class MarkdownParserTest {
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
         assertEquals(3, firstParagraph.getNumberOfSentences());
+
         assertEquals("Is Tokyu a good railway company?", doc.getSection(0).getParagraph(0).getSentence(0).content);
         assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
+        assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
+
         assertEquals(" The company is reliable.", doc.getSection(0).getParagraph(0).getSentence(1).content);
         assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
+        assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
+
         assertEquals(" In addition it is rich!", doc.getSection(0).getParagraph(0).getSentence(2).content);
         assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(2).lineNum);
+        assertEquals(57, doc.getSection(0).getParagraph(0).getSentence(2).startPositionOffset);
     }
 
     @Test
@@ -225,6 +238,27 @@ public class MarkdownParserTest {
     }
 
     @Test
+    public void testGenerateDocumentWithTwoSentencesWithMultipleShortLine() {
+        String sampleText = "Tokyu\n" +
+                "is a good\n" +
+                "railway company. But there\n" +
+                "are competitors.";
+        Document doc = createFileContent(sampleText);
+        Section firstSections = doc.getSection(0);
+        Paragraph firstParagraph = firstSections.getParagraph(0);
+        assertEquals(2, firstParagraph.getNumberOfSentences());
+
+        assertEquals("Tokyu is a good railway company.", doc.getSection(0).getParagraph(0).getSentence(0).content);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
+        assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
+        // assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(0).offsetMap.size()); TODO FIXMLE
+
+        assertEquals(" But there are competitors.", doc.getSection(0).getParagraph(0).getSentence(1).content);
+        assertEquals(3, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
+        assertEquals(16, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
+    }
+
+        @Test
     public void testGenerateDocumentWitVoidContent() {
         String sampleText = "";
         Document doc = createFileContent(sampleText);

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -197,31 +197,31 @@ public class MarkdownParserTest {
     @Test
     public void testGenerateDocumentWithMultipleSentenceInMultipleSentences() {
         String sampleText = "Tokyu is a good railway company. The company is reliable. In addition it\n";
-        sampleText += " is rich. I like the company. However someone does not like it.";
+        sampleText += "is rich. I like the company. However someone does not like it.";
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
         assertEquals(5, firstParagraph.getNumberOfSentences());
 
         assertEquals("Tokyu is a good railway company.", doc.getSection(0).getParagraph(0).getSentence(0).content);
-        //assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
-        //assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
+        assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
 
         assertEquals(" The company is reliable.", doc.getSection(0).getParagraph(0).getSentence(1).content);
-        //assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
-        //assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
+        assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
 
         assertEquals(" In addition it is rich.", doc.getSection(0).getParagraph(0).getSentence(2).content);
-        //assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(2).lineNum);
-        //assertEquals(54, doc.getSection(0).getParagraph(0).getSentence(2).startPositionOffset);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(2).lineNum);
+        assertEquals(57, doc.getSection(0).getParagraph(0).getSentence(2).startPositionOffset);
 
         assertEquals(" I like the company.", doc.getSection(0).getParagraph(0).getSentence(3).content);
-        //assertEquals(2, doc.getSection(0).getParagraph(0).getSentence(3).lineNum);
-        //assertEquals(8, doc.getSection(0).getParagraph(0).getSentence(3).startPositionOffset);
+        assertEquals(2, doc.getSection(0).getParagraph(0).getSentence(3).lineNum);
+        assertEquals(8, doc.getSection(0).getParagraph(0).getSentence(3).startPositionOffset);
 
         assertEquals(" However someone does not like it.", doc.getSection(0).getParagraph(0).getSentence(4).content);
-        //assertEquals(2, doc.getSection(0).getParagraph(0).getSentence(4).lineNum);
-        //assertEquals(24, doc.getSection(0).getParagraph(0).getSentence(4).startPositionOffset);
+        assertEquals(2, doc.getSection(0).getParagraph(0).getSentence(4).lineNum);
+        assertEquals(28, doc.getSection(0).getParagraph(0).getSentence(4).startPositionOffset);
     }
 
     @Test
@@ -291,6 +291,38 @@ public class MarkdownParserTest {
         assertEquals("the url is not Google.",
                 firstParagraph.getSentence(0).content);
     }
+
+    @Test
+    public void testPlainTwoLinkWithinOneLine() {
+        // PegDown Parser is related tovisit(AutoLinkNode) method
+        String sampleText = "url of google is http://google.com. http://yahoo.com is Yahoo url.";
+        Document doc = createFileContent(sampleText);
+        Section firstSections = doc.getSection(0);
+        Paragraph firstParagraph = firstSections.getParagraph(0);
+        assertEquals(2, firstParagraph.getNumberOfSentences());
+        assertEquals(1, firstParagraph.getSentence(0).links.size());
+        assertEquals("http://google.com", firstParagraph.getSentence(0).links.get(0));
+        assertEquals("url of google is http://google.com.",
+                firstParagraph.getSentence(0).content);
+        assertEquals("http://yahoo.com", firstParagraph.getSentence(1).links.get(0));
+        assertEquals(" http://yahoo.com is Yahoo url.",
+                firstParagraph.getSentence(1).content);
+    }
+
+//    @Test
+//    public void testPlainTwoLinkWithinOneSentence() {
+//        String sampleText = "http://yahoo.com and http://google.com is Google and Yahoo urls.";
+//        Document doc = createFileContent(sampleText);
+//        Section firstSections = doc.getSection(0);
+//        Paragraph firstParagraph = firstSections.getParagraph(0);
+//        assertEquals(1, firstParagraph.getNumberOfSentences());
+//        assertEquals(2, firstParagraph.getSentence(0).links.size());
+//        assertEquals("http://yahoo.com", firstParagraph.getSentence(0).links.get(0));
+//        assertEquals("http://google.com", firstParagraph.getSentence(0).links.get(1));
+//        assertEquals("http://yahoo.com and http://google.com is Google and Yahoo urls.",
+//                firstParagraph.getSentence(0).content);
+//
+//    }
 
     @Test
     public void testLinkWithoutTag() {

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -24,12 +24,15 @@ import cc.redpen.model.ListBlock;
 import cc.redpen.model.Paragraph;
 import cc.redpen.model.Section;
 import cc.redpen.parser.DocumentParser;
+import cc.redpen.parser.LineOffset;
 import cc.redpen.parser.SentenceExtractor;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static cc.redpen.config.SymbolType.COMMA;
 import static cc.redpen.config.SymbolType.FULL_STOP;
@@ -258,7 +261,6 @@ public class MarkdownParserTest {
         assertEquals(16, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
     }
 
-
     @Test
     public void testMappingTableWithShortSentence() {
         String sampleText = "Tsu is a city.";
@@ -272,6 +274,7 @@ public class MarkdownParserTest {
         assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
         assertEquals(doc.getSection(0).getParagraph(0).getSentence(0).content.length(),
                 doc.getSection(0).getParagraph(0).getSentence(0).offsetMap.size());
+
     }
 
         @Test
@@ -316,7 +319,7 @@ public class MarkdownParserTest {
 
     @Test
     public void testPlainLink() {
-        String sampleText = "this is not a [pen], but also this is not [Google](http://google.com) either.";
+        String sampleText = "It is not [Google](http://google.com).";
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
@@ -324,8 +327,34 @@ public class MarkdownParserTest {
         assertEquals(1, firstParagraph.getSentence(0).links.size());
         // PegDown Parser is related to visit(RefLinkNode) method
         assertEquals("http://google.com", firstParagraph.getSentence(0).links.get(0));
-        assertEquals("this is not a pen, but also this is not Google either.",
+        assertEquals("It is not Google.",
                 firstParagraph.getSentence(0).content);
+        assertEquals(firstParagraph.getSentence(0).content.length(),
+                firstParagraph.getSentence(0).offsetMap.size());
+
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 0),
+                new LineOffset(1, 1),
+                new LineOffset(1, 2),
+                new LineOffset(1, 3),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 6),
+                new LineOffset(1, 7),
+                new LineOffset(1, 8),
+                new LineOffset(1, 9),
+                new LineOffset(1, 11),
+                new LineOffset(1, 12),
+                new LineOffset(1, 13),
+                new LineOffset(1, 14),
+                new LineOffset(1, 15),
+                new LineOffset(1, 16),
+                new LineOffset(1, 37));
+
+        assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).offsetMap.get(i));
+        }
     }
 
     @Test
@@ -389,59 +418,200 @@ public class MarkdownParserTest {
     }
 
     @Test
-    public void testDocumentWithItalicWord() {
-        String sampleText = "This is a *good* day.\n";
+    public void testDocumentWithSimpleSentence() {
+        String sampleText = "It is a good day.";
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
-        assertEquals("This is a good day.", firstParagraph.getSentence(0).content);
+        assertEquals("It is a good day.", firstParagraph.getSentence(0).content);
+        assertEquals(17, firstParagraph.getSentence(0).content.length());
+        assertEquals(1, firstParagraph.getSentence(0).lineNum);
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 0),
+                new LineOffset(1, 1),
+                new LineOffset(1, 2),
+                new LineOffset(1, 3),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 6),
+                new LineOffset(1, 7),
+                new LineOffset(1, 8),
+                new LineOffset(1, 9),
+                new LineOffset(1, 10),
+                new LineOffset(1, 11),
+                new LineOffset(1, 12),
+                new LineOffset(1, 13),
+                new LineOffset(1, 14),
+                new LineOffset(1, 15),
+                new LineOffset(1, 16));
+
+        assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).offsetMap.get(i));
+        }
+    }
+
+    @Test
+    public void testDocumentWithItalicWord() {
+        String sampleText = "It is a *good* day.";
+        Document doc = createFileContent(sampleText);
+        Section firstSections = doc.getSection(0);
+        Paragraph firstParagraph = firstSections.getParagraph(0);
+        assertEquals("It is a good day.", firstParagraph.getSentence(0).content);
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 0),
+                new LineOffset(1, 1),
+                new LineOffset(1, 2),
+                new LineOffset(1, 3),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 6),
+                new LineOffset(1, 7),
+                new LineOffset(1, 9),
+                new LineOffset(1, 10),
+                new LineOffset(1, 11),
+                new LineOffset(1, 12),
+                new LineOffset(1, 14),
+                new LineOffset(1, 15),
+                new LineOffset(1, 16),
+                new LineOffset(1, 17),
+                new LineOffset(1, 18));
+
+        assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).offsetMap.get(i));
+        }
     }
 
     @Test
     public void testDocumentWithMultipleItalicWords() {
-        String sampleText = "*This* is a _good_ day.\n";
+        String sampleText = "*It* is a _good_ day.\n";
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
-        assertEquals("This is a good day.", firstParagraph.getSentence(0).content);
+        assertEquals("It is a good day.", firstParagraph.getSentence(0).content);
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 1),
+                new LineOffset(1, 2),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 6),
+                new LineOffset(1, 7),
+                new LineOffset(1, 8),
+                new LineOffset(1, 9),
+                new LineOffset(1, 11),
+                new LineOffset(1, 12),
+                new LineOffset(1, 13),
+                new LineOffset(1, 14),
+                new LineOffset(1, 16),
+                new LineOffset(1, 17),
+                new LineOffset(1, 18),
+                new LineOffset(1, 19),
+                new LineOffset(1, 20));
+
+        assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).offsetMap.get(i));
+        }
     }
 
     @Test
     public void testDocumentWithMultipleNearStrongWords() {
-        String sampleText = "This is **a** __good__ day.\n";
+        String sampleText = "It is **a** __good__ day.\n";
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
-        assertEquals("This is a good day.", firstParagraph.getSentence(0).content);
+        assertEquals("It is a good day.", firstParagraph.getSentence(0).content);
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 0),
+                new LineOffset(1, 1),
+                new LineOffset(1, 2),
+                new LineOffset(1, 3),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 8),
+                new LineOffset(1, 11),
+                new LineOffset(1, 14),
+                new LineOffset(1, 15),
+                new LineOffset(1, 16),
+                new LineOffset(1, 17),
+                new LineOffset(1, 20),
+                new LineOffset(1, 21),
+                new LineOffset(1, 22),
+                new LineOffset(1, 23),
+                new LineOffset(1, 24));
+        assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).offsetMap.get(i));
+        }
     }
 
     @Test
-    public void testDocumentWithItalicExpression() {
-        String sampleText = "This is *a good* day.\n";
-        Document doc = createFileContent(sampleText);
-        Section firstSections = doc.getSection(0);
-        Paragraph firstParagraph = firstSections.getParagraph(0);
-        assertEquals("This is a good day.", firstParagraph.getSentence(0).content);
-    }
-
-
-    @Test
-    public void testDocumentWithHeaderCotainingMultipleSentences()
+    public void testDocumentWithHeaderContainingMultipleSentences()
             throws UnsupportedEncodingException {
         String sampleText = "";
         sampleText += "# About Gunma. About Saitama.\n";
         sampleText += "Gunma is located at west of Saitama.\n";
-        sampleText += "The word also have posive meaning. Hower it is a bit wired.";
+        sampleText += "The word also have positive meaning. However it is a bit wired.";
 
         Document doc = createFileContent(sampleText);
         Section lastSection = doc.getSection(doc.size() - 1);
         assertEquals(2, lastSection.getHeaderContentsListSize());
+
         assertEquals("About Gunma.", lastSection.getHeaderContent(0).content);
+        assertEquals(1, lastSection.getHeaderContent(0).lineNum);
+        assertEquals(2, lastSection.getHeaderContent(0).startPositionOffset);
+
+        List<LineOffset> expectedOffsets1 = initializeMappingTable(
+                new LineOffset(1, 2),
+                new LineOffset(1, 3),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 6),
+                new LineOffset(1, 7),
+                new LineOffset(1, 8),
+                new LineOffset(1, 9),
+                new LineOffset(1, 10),
+                new LineOffset(1, 11),
+                new LineOffset(1, 12),
+                new LineOffset(1, 13));
+
+        assertEquals(expectedOffsets1.size(), lastSection.getHeaderContent(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets1.size() ; i++) {
+            assertEquals(expectedOffsets1.get(i),
+                    lastSection.getHeaderContent(0).offsetMap.get(i));
+        }
+
+        List<LineOffset> expectedOffsets2 = initializeMappingTable(
+                new LineOffset(1, 14),
+                new LineOffset(1, 15),
+                new LineOffset(1, 16),
+                new LineOffset(1, 17),
+                new LineOffset(1, 18),
+                new LineOffset(1, 19),
+                new LineOffset(1, 20),
+                new LineOffset(1, 21),
+                new LineOffset(1, 22),
+                new LineOffset(1, 23),
+                new LineOffset(1, 24),
+                new LineOffset(1, 25),
+                new LineOffset(1, 26),
+                new LineOffset(1, 27),
+                new LineOffset(1, 28));
+
         assertEquals(" About Saitama.", lastSection.getHeaderContent(1).content);
+        assertEquals(1, lastSection.getHeaderContent(1).lineNum);
+        assertEquals(14, lastSection.getHeaderContent(1).startPositionOffset);
+
+        assertEquals(expectedOffsets2.size(), lastSection.getHeaderContent(1).offsetMap.size());
+        for (int i = 0; i < expectedOffsets2.size() ; i++) {
+            assertEquals(expectedOffsets2.get(i),
+                    lastSection.getHeaderContent(1).offsetMap.get(i));
+        }
     }
 
     @Test
-    public void testDocumentWithHeaderWitoutPeriod()
+    public void testDocumentWithHeaderWithoutPeriods()
             throws UnsupportedEncodingException {
         String sampleText = "";
         sampleText += "# About Gunma\n";
@@ -452,6 +622,25 @@ public class MarkdownParserTest {
         Section lastSection = doc.getSection(doc.size() - 1);
         assertEquals(1, lastSection.getHeaderContentsListSize());
         assertEquals("About Gunma", lastSection.getHeaderContent(0).content);
+        assertEquals(2, lastSection.getHeaderContent(0).startPositionOffset);
+
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 2),
+                new LineOffset(1, 3),
+                new LineOffset(1, 4),
+                new LineOffset(1, 5),
+                new LineOffset(1, 6),
+                new LineOffset(1, 7),
+                new LineOffset(1, 8),
+                new LineOffset(1, 9),
+                new LineOffset(1, 10),
+                new LineOffset(1, 11),
+                new LineOffset(1, 12));
+        assertEquals(expectedOffsets.size(), lastSection.getHeaderContent(0).offsetMap.size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i),
+                    lastSection.getHeaderContent(0).offsetMap.get(i));
+        }
     }
 
     @Test
@@ -623,11 +812,20 @@ public class MarkdownParserTest {
         Document doc = null;
         try {
             Configuration configuration = new Configuration.ConfigurationBuilder().build();
-            doc = parser.parse(inputDocumentString, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer());
+            doc = parser.parse(inputDocumentString, new SentenceExtractor(configuration.getSymbolTable()),
+                    configuration.getTokenizer());
         } catch (RedPenException e) {
             e.printStackTrace();
             fail();
         }
         return doc;
+    }
+
+    private static List<LineOffset> initializeMappingTable(LineOffset... offsets) {
+        List<LineOffset> offsetTable = new ArrayList<>();
+        for (LineOffset offset : offsets) {
+            offsetTable.add(offset);
+        }
+        return offsetTable;
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -251,11 +251,27 @@ public class MarkdownParserTest {
         assertEquals("Tokyu is a good railway company.", doc.getSection(0).getParagraph(0).getSentence(0).content);
         assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
         assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
-        // assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(0).offsetMap.size()); TODO FIXMLE
+        assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(0).offsetMap.size());
 
         assertEquals(" But there are competitors.", doc.getSection(0).getParagraph(0).getSentence(1).content);
         assertEquals(3, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
         assertEquals(16, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
+    }
+
+
+    @Test
+    public void testMappingTableWithShortSentence() {
+        String sampleText = "Tsu is a city.";
+        Document doc = createFileContent(sampleText);
+        Section firstSections = doc.getSection(0);
+        Paragraph firstParagraph = firstSections.getParagraph(0);
+        assertEquals(1, firstParagraph.getNumberOfSentences());
+        assertEquals("Tsu is a city.", doc.getSection(0).getParagraph(0).getSentence(0).content);
+
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
+        assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
+        assertEquals(doc.getSection(0).getParagraph(0).getSentence(0).content.length(),
+                doc.getSection(0).getParagraph(0).getSentence(0).offsetMap.size());
     }
 
         @Test

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -175,6 +175,7 @@ public class MarkdownParserTest {
         assertEquals(3, firstParagraph.getNumberOfSentences());
         for (int i = 0; i < expectedResult.length; i++) {
             assertEquals(expectedResult[i], firstParagraph.getSentence(i).content);
+            assertEquals(1, firstParagraph.getSentence(i).lineNum);
         }
     }
 
@@ -186,18 +187,41 @@ public class MarkdownParserTest {
         Paragraph firstParagraph = firstSections.getParagraph(0);
         assertEquals(3, firstParagraph.getNumberOfSentences());
         assertEquals("Is Tokyu a good railway company?", doc.getSection(0).getParagraph(0).getSentence(0).content);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
         assertEquals(" The company is reliable.", doc.getSection(0).getParagraph(0).getSentence(1).content);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
         assertEquals(" In addition it is rich!", doc.getSection(0).getParagraph(0).getSentence(2).content);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(2).lineNum);
     }
 
     @Test
     public void testGenerateDocumentWithMultipleSentenceInMultipleSentences() {
-        String sampleText = "Tokyu is a good railway company. The company is reliable. In addition it is rich.\n";
-        sampleText += "I like the company. Howerver someone does not like it.";
+        String sampleText = "Tokyu is a good railway company. The company is reliable. In addition it\n";
+        sampleText += " is rich. I like the company. However someone does not like it.";
         Document doc = createFileContent(sampleText);
         Section firstSections = doc.getSection(0);
         Paragraph firstParagraph = firstSections.getParagraph(0);
         assertEquals(5, firstParagraph.getNumberOfSentences());
+
+        assertEquals("Tokyu is a good railway company.", doc.getSection(0).getParagraph(0).getSentence(0).content);
+        //assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
+        //assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).startPositionOffset);
+
+        assertEquals(" The company is reliable.", doc.getSection(0).getParagraph(0).getSentence(1).content);
+        //assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
+        //assertEquals(32, doc.getSection(0).getParagraph(0).getSentence(1).startPositionOffset);
+
+        assertEquals(" In addition it is rich.", doc.getSection(0).getParagraph(0).getSentence(2).content);
+        //assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(2).lineNum);
+        //assertEquals(54, doc.getSection(0).getParagraph(0).getSentence(2).startPositionOffset);
+
+        assertEquals(" I like the company.", doc.getSection(0).getParagraph(0).getSentence(3).content);
+        //assertEquals(2, doc.getSection(0).getParagraph(0).getSentence(3).lineNum);
+        //assertEquals(8, doc.getSection(0).getParagraph(0).getSentence(3).startPositionOffset);
+
+        assertEquals(" However someone does not like it.", doc.getSection(0).getParagraph(0).getSentence(4).content);
+        //assertEquals(2, doc.getSection(0).getParagraph(0).getSentence(4).lineNum);
+        //assertEquals(24, doc.getSection(0).getParagraph(0).getSentence(4).startPositionOffset);
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -55,7 +55,7 @@ public class MarkdownParserTest {
         sampleText += "# About Gekioko.\n";
         sampleText += "Gekioko pun pun maru means very very angry.\n";
         sampleText += "\n";
-        sampleText += "The word also have posive meaning.\n";
+        sampleText += "The word also has a positive meaning.\n";
         sampleText += "## About Gunma.\n";
         sampleText += "\n";
         sampleText += "Gunma is located at west of Saitama.\n";
@@ -84,18 +84,23 @@ public class MarkdownParserTest {
         assertEquals(1, secondSection.getHeaderContentsListSize());
         assertEquals("About Gekioko.", secondSection.getHeaderContent(0).content);
         assertEquals(1, secondSection.getHeaderContent(0).lineNum);
+        assertEquals(2, secondSection.getHeaderContent(0).startPositionOffset);
         assertEquals(0, secondSection.getNumberOfLists());
         assertEquals(2, secondSection.getNumberOfParagraphs());
         assertEquals(1, secondSection.getNumberOfSubsections());
         assertEquals(firstSection, secondSection.getParentSection());
+
         // validate paragraph in 2nd section
         assertEquals(1, secondSection.getParagraph(0).getNumberOfSentences());
         assertEquals(true, secondSection.getParagraph(0).getSentence(0).isFirstSentence);
         assertEquals(2, secondSection.getParagraph(0).getSentence(0).lineNum);
+        assertEquals(0, secondSection.getParagraph(0).getSentence(0).startPositionOffset);
         assertEquals(1, secondSection.getParagraph(1).getNumberOfSentences());
         assertEquals(true, secondSection.getParagraph(1).getSentence(0).isFirstSentence);
         assertEquals(4, secondSection.getParagraph(1).getSentence(0).lineNum);
+        assertEquals(0, secondSection.getParagraph(1).getSentence(0).startPositionOffset);
 
+        // 3rd section
         Section lastSection = doc.getSection(doc.size() - 1);
         assertEquals(1, lastSection.getNumberOfLists());
         assertEquals(5, lastSection.getListBlock(0).getNumberOfListElements());
@@ -103,17 +108,20 @@ public class MarkdownParserTest {
         assertEquals(1, lastSection.getHeaderContentsListSize());
         assertEquals(0, lastSection.getNumberOfSubsections());
         assertEquals("About Gunma.", lastSection.getHeaderContent(0).content);
+        assertEquals(3, lastSection.getHeaderContent(0).startPositionOffset);
         assertEquals(secondSection, lastSection.getParentSection());
 
-        // validate paragraph in last section
+        // validate paragraphs in last section
         assertEquals(1, lastSection.getParagraph(0).getNumberOfSentences());
         assertEquals(true, lastSection.getParagraph(0).getSentence(0).isFirstSentence);
         assertEquals(7, lastSection.getParagraph(0).getSentence(0).lineNum);
+        assertEquals(0, lastSection.getParagraph(0).getSentence(0).startPositionOffset);
         assertEquals(2, lastSection.getParagraph(1).getNumberOfSentences());
         assertEquals(true, lastSection.getParagraph(1).getSentence(0).isFirstSentence);
         assertEquals(15, lastSection.getParagraph(1).getSentence(0).lineNum);
         assertEquals(false, lastSection.getParagraph(1).getSentence(1).isFirstSentence);
         assertEquals(15, lastSection.getParagraph(1).getSentence(1).lineNum);
+        assertEquals(36, lastSection.getParagraph(1).getSentence(1).startPositionOffset);
     }
 
     @Test
@@ -126,18 +134,33 @@ public class MarkdownParserTest {
         sampleText += "    - Denentoshi Line\n";
         sampleText += "- Keio\n";
         sampleText += "- Odakyu\n";
+
         Document doc = createFileContent(sampleText);
         assertEquals(5, doc.getSection(0).getListBlock(0).getNumberOfListElements());
         assertEquals("Tokyu", doc.getSection(0).getListBlock(0).getListElement(0).getSentence(0).content);
         assertEquals(1, doc.getSection(0).getListBlock(0).getListElement(0).getLevel());
+        assertEquals(3, doc.getSection(0).getListBlock(0).getListElement(0).getSentence(0).lineNum);
+        assertEquals(2, doc.getSection(0).getListBlock(0).getListElement(0).getSentence(0).startPositionOffset);
+
         assertEquals("Toyoko Line", doc.getSection(0).getListBlock(0).getListElement(1).getSentence(0).content);
         assertEquals(2, doc.getSection(0).getListBlock(0).getListElement(1).getLevel());
+        assertEquals(4, doc.getSection(0).getListBlock(0).getListElement(1).getSentence(0).lineNum);
+        assertEquals(6, doc.getSection(0).getListBlock(0).getListElement(1).getSentence(0).startPositionOffset);
+
         assertEquals("Denentoshi Line", doc.getSection(0).getListBlock(0).getListElement(2).getSentence(0).content);
         assertEquals(2, doc.getSection(0).getListBlock(0).getListElement(2).getLevel());
+        assertEquals(5, doc.getSection(0).getListBlock(0).getListElement(2).getSentence(0).lineNum);
+        assertEquals(6, doc.getSection(0).getListBlock(0).getListElement(2).getSentence(0).startPositionOffset);
+
         assertEquals("Keio", doc.getSection(0).getListBlock(0).getListElement(3).getSentence(0).content);
         assertEquals(1, doc.getSection(0).getListBlock(0).getListElement(3).getLevel());
+        assertEquals(6, doc.getSection(0).getListBlock(0).getListElement(3).getSentence(0).lineNum);
+        assertEquals(2, doc.getSection(0).getListBlock(0).getListElement(3).getSentence(0).startPositionOffset);
+
         assertEquals("Odakyu", doc.getSection(0).getListBlock(0).getListElement(4).getSentence(0).content);
         assertEquals(1, doc.getSection(0).getListBlock(0).getListElement(4).getLevel());
+        assertEquals(7, doc.getSection(0).getListBlock(0).getListElement(4).getSentence(0).lineNum);
+        assertEquals(2, doc.getSection(0).getListBlock(0).getListElement(4).getSentence(0).startPositionOffset);
     }
 
     @Test
@@ -501,6 +524,4 @@ public class MarkdownParserTest {
         }
         return doc;
     }
-
-
 }

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -83,7 +83,7 @@ public class MarkdownParserTest {
         final Section secondSection = doc.getSection(1);
         assertEquals(1, secondSection.getHeaderContentsListSize());
         assertEquals("About Gekioko.", secondSection.getHeaderContent(0).content);
-        assertEquals(1, secondSection.getHeaderContent(0).position);
+        assertEquals(1, secondSection.getHeaderContent(0).lineNum);
         assertEquals(0, secondSection.getNumberOfLists());
         assertEquals(2, secondSection.getNumberOfParagraphs());
         assertEquals(1, secondSection.getNumberOfSubsections());
@@ -91,10 +91,10 @@ public class MarkdownParserTest {
         // validate paragraph in 2nd section
         assertEquals(1, secondSection.getParagraph(0).getNumberOfSentences());
         assertEquals(true, secondSection.getParagraph(0).getSentence(0).isFirstSentence);
-        assertEquals(2, secondSection.getParagraph(0).getSentence(0).position);
+        assertEquals(2, secondSection.getParagraph(0).getSentence(0).lineNum);
         assertEquals(1, secondSection.getParagraph(1).getNumberOfSentences());
         assertEquals(true, secondSection.getParagraph(1).getSentence(0).isFirstSentence);
-        assertEquals(4, secondSection.getParagraph(1).getSentence(0).position);
+        assertEquals(4, secondSection.getParagraph(1).getSentence(0).lineNum);
 
         Section lastSection = doc.getSection(doc.size() - 1);
         assertEquals(1, lastSection.getNumberOfLists());
@@ -108,12 +108,12 @@ public class MarkdownParserTest {
         // validate paragraph in last section
         assertEquals(1, lastSection.getParagraph(0).getNumberOfSentences());
         assertEquals(true, lastSection.getParagraph(0).getSentence(0).isFirstSentence);
-        assertEquals(7, lastSection.getParagraph(0).getSentence(0).position);
+        assertEquals(7, lastSection.getParagraph(0).getSentence(0).lineNum);
         assertEquals(2, lastSection.getParagraph(1).getNumberOfSentences());
         assertEquals(true, lastSection.getParagraph(1).getSentence(0).isFirstSentence);
-        assertEquals(15, lastSection.getParagraph(1).getSentence(0).position);
+        assertEquals(15, lastSection.getParagraph(1).getSentence(0).lineNum);
         assertEquals(false, lastSection.getParagraph(1).getSentence(1).isFirstSentence);
-        assertEquals(15, lastSection.getParagraph(1).getSentence(1).position);
+        assertEquals(15, lastSection.getParagraph(1).getSentence(1).lineNum);
     }
 
     @Test
@@ -358,7 +358,7 @@ public class MarkdownParserTest {
         ListBlock listBlock = lastSection.getListBlock(0);
         assertEquals(1, listBlock.getNumberOfListElements());
         assertEquals(1, listBlock.getListElement(0).getNumberOfSentences());
-        assertEquals(2, listBlock.getListElement(0).getSentence(0).position);
+        assertEquals(2, listBlock.getListElement(0).getSentence(0).lineNum);
         assertEquals("Gunma is located at west of Saitama",
                 listBlock.getListElement(0).getSentence(0).content);
     }
@@ -388,9 +388,9 @@ public class MarkdownParserTest {
         assertEquals(h2Section.getParentSection(), h1Section);
         assertEquals(rootSection.getParentSection(), null);
 
-        assertEquals(0, rootSection.getHeaderContent(0).position);
-        assertEquals(1, h1Section.getHeaderContent(0).position);
-        assertEquals(5, h2Section.getHeaderContent(0).position);
+        assertEquals(0, rootSection.getHeaderContent(0).lineNum);
+        assertEquals(1, h1Section.getHeaderContent(0).lineNum);
+        assertEquals(5, h2Section.getHeaderContent(0).lineNum);
     }
 
     @Test
@@ -420,9 +420,9 @@ public class MarkdownParserTest {
         assertEquals(h2Section.getParentSection(), h1Section);
         assertEquals(rootSection.getParentSection(), null);
 
-        assertEquals(0, rootSection.getHeaderContent(0).position);
-        assertEquals(1, h1Section.getHeaderContent(0).position);
-        assertEquals(6, h2Section.getHeaderContent(0).position);
+        assertEquals(0, rootSection.getHeaderContent(0).lineNum);
+        assertEquals(1, h1Section.getHeaderContent(0).lineNum);
+        assertEquals(6, h2Section.getHeaderContent(0).lineNum);
     }
 
     /**

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -274,7 +274,7 @@ public class MarkdownParserTest {
         assertEquals(1, firstParagraph.getSentence(0).links.size());
         // PegDown Parser is related to visit(RefLinkNode) method
         assertEquals("http://google.com", firstParagraph.getSentence(0).links.get(0));
-        assertEquals("this is not a [pen], but also this is not Google either.",
+        assertEquals("this is not a pen, but also this is not Google either.",
                 firstParagraph.getSentence(0).content);
     }
 
@@ -309,20 +309,20 @@ public class MarkdownParserTest {
                 firstParagraph.getSentence(1).content);
     }
 
-//    @Test
-//    public void testPlainTwoLinkWithinOneSentence() {
-//        String sampleText = "http://yahoo.com and http://google.com is Google and Yahoo urls.";
-//        Document doc = createFileContent(sampleText);
-//        Section firstSections = doc.getSection(0);
-//        Paragraph firstParagraph = firstSections.getParagraph(0);
-//        assertEquals(1, firstParagraph.getNumberOfSentences());
-//        assertEquals(2, firstParagraph.getSentence(0).links.size());
-//        assertEquals("http://yahoo.com", firstParagraph.getSentence(0).links.get(0));
-//        assertEquals("http://google.com", firstParagraph.getSentence(0).links.get(1));
-//        assertEquals("http://yahoo.com and http://google.com is Google and Yahoo urls.",
-//                firstParagraph.getSentence(0).content);
-//
-//    }
+    @Test
+    public void testPlainTwoLinkWithinOneSentence() {
+        String sampleText = "http://yahoo.com and http://google.com is Google and Yahoo urls.";
+        Document doc = createFileContent(sampleText);
+        Section firstSections = doc.getSection(0);
+        Paragraph firstParagraph = firstSections.getParagraph(0);
+        assertEquals(1, firstParagraph.getNumberOfSentences());
+        assertEquals(2, firstParagraph.getSentence(0).links.size());
+        assertEquals("http://yahoo.com", firstParagraph.getSentence(0).links.get(1));
+        assertEquals("http://google.com", firstParagraph.getSentence(0).links.get(0));
+        assertEquals("http://yahoo.com and http://google.com is Google and Yahoo urls.",
+                firstParagraph.getSentence(0).content);
+
+    }
 
     @Test
     public void testLinkWithoutTag() {

--- a/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
@@ -92,17 +92,17 @@ public class PlainTextParserTest {
         assertEquals(3, extractParagraphs(section).size());
 
         assertEquals(2, section.getParagraph(0).getNumberOfSentences());
-        assertEquals(1, section.getParagraph(0).getSentence(0).position);
-        assertEquals(2, section.getParagraph(0).getSentence(1).position);
+        assertEquals(1, section.getParagraph(0).getSentence(0).lineNum);
+        assertEquals(2, section.getParagraph(0).getSentence(1).lineNum);
 
         assertEquals(2, section.getParagraph(1).getNumberOfSentences());
-        assertEquals(4, section.getParagraph(1).getSentence(0).position);
-        assertEquals(5, section.getParagraph(1).getSentence(1).position);
+        assertEquals(4, section.getParagraph(1).getSentence(0).lineNum);
+        assertEquals(5, section.getParagraph(1).getSentence(1).lineNum);
 
         assertEquals(3, section.getParagraph(2).getNumberOfSentences());
-        assertEquals(7, section.getParagraph(2).getSentence(0).position);
-        assertEquals(8, section.getParagraph(2).getSentence(1).position);
-        assertEquals(9, section.getParagraph(2).getSentence(2).position);
+        assertEquals(7, section.getParagraph(2).getSentence(0).lineNum);
+        assertEquals(8, section.getParagraph(2).getSentence(1).lineNum);
+        assertEquals(9, section.getParagraph(2).getSentence(2).lineNum);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class PlainTextParserTest {
         for (int i = 0; i < expectedResult.length; i++) {
             assertEquals(expectedResult[i], paragraph.getSentence(i).content);
         }
-        assertEquals(0, section.getHeaderContent(0).position);
+        assertEquals(0, section.getHeaderContent(0).lineNum);
         assertEquals("", section.getHeaderContent(0).content);
     }
 
@@ -160,7 +160,7 @@ public class PlainTextParserTest {
         for (int i = 0; i < expectedResult.length; i++) {
             assertEquals(expectedResult[i], paragraph.getSentence(i).content);
         }
-        assertEquals(0, section.getHeaderContent(0).position);
+        assertEquals(0, section.getHeaderContent(0).lineNum);
         assertEquals("", section.getHeaderContent(0).content);
     }
 

--- a/redpen-core/src/test/java/cc/redpen/WikiParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/WikiParserTest.java
@@ -537,20 +537,20 @@ public class WikiParserTest {
         assertEquals(h2Section.getParentSection(), h1Section);
         assertEquals(rootSection.getParentSection(), null);
 
-        assertEquals(1, rootSection.getHeaderContent(0).position);
+        assertEquals(1, rootSection.getHeaderContent(0).lineNum);
         assertEquals(0, rootSection.getNumberOfParagraphs());
 
-        assertEquals(1, h1Section.getHeaderContent(0).position);
+        assertEquals(1, h1Section.getHeaderContent(0).lineNum);
         assertEquals(2, h1Section.getNumberOfParagraphs());
         assertEquals(1, h1Section.getParagraph(0).getNumberOfSentences());
-        assertEquals(2, h1Section.getParagraph(0).getSentence(0).position);
+        assertEquals(2, h1Section.getParagraph(0).getSentence(0).lineNum);
         assertEquals(1, h1Section.getParagraph(1).getNumberOfSentences());
-        assertEquals(4, h1Section.getParagraph(1).getSentence(0).position);
+        assertEquals(4, h1Section.getParagraph(1).getSentence(0).lineNum);
 
-        assertEquals(5, h2Section.getHeaderContent(0).position);
+        assertEquals(5, h2Section.getHeaderContent(0).lineNum);
         assertEquals(1, h2Section.getNumberOfParagraphs());
         assertEquals(1, h2Section.getParagraph(0).getNumberOfSentences());
-        assertEquals(6, h2Section.getParagraph(0).getSentence(0).position);
+        assertEquals(6, h2Section.getParagraph(0).getSentence(0).lineNum);
     }
 
     @Test
@@ -571,13 +571,13 @@ public class WikiParserTest {
         assertEquals(h1Section.getParentSection(), rootSection);
         assertEquals(rootSection.getParentSection(), null);
 
-        assertEquals(1, rootSection.getHeaderContent(0).position);
+        assertEquals(1, rootSection.getHeaderContent(0).lineNum);
         assertEquals(0, rootSection.getNumberOfParagraphs());
 
-        assertEquals(1, h1Section.getHeaderContent(0).position);
+        assertEquals(1, h1Section.getHeaderContent(0).lineNum);
         assertEquals(1, h1Section.getNumberOfParagraphs());
         assertEquals(1, h1Section.getParagraph(0).getNumberOfSentences());
-        assertEquals(2, h1Section.getParagraph(0).getSentence(0).position);
+        assertEquals(2, h1Section.getParagraph(0).getSentence(0).lineNum);
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/model/DocumentCollectionTest.java
+++ b/redpen-core/src/test/java/cc/redpen/model/DocumentCollectionTest.java
@@ -30,10 +30,10 @@ public class DocumentCollectionTest {
         assertEquals(2, docs.get(0).getSection(0).getParagraph(0).getNumberOfSentences());
         assertEquals("sentence0", docs.get(0).getSection(0).getParagraph(0).getSentence(0).content);
         assertEquals(true, docs.get(0).getSection(0).getParagraph(0).getSentence(0).isFirstSentence);
-        assertEquals(0, docs.get(0).getSection(0).getParagraph(0).getSentence(0).position);
+        assertEquals(0, docs.get(0).getSection(0).getParagraph(0).getSentence(0).lineNum);
         assertEquals("sentence1", docs.get(0).getSection(0).getParagraph(0).getSentence(1).content);
         assertEquals(false, docs.get(0).getSection(0).getParagraph(0).getSentence(1).isFirstSentence);
-        assertEquals(1, docs.get(0).getSection(0).getParagraph(0).getSentence(1).position);
+        assertEquals(1, docs.get(0).getSection(0).getParagraph(0).getSentence(1).lineNum);
     }
 
     @Test
@@ -66,10 +66,10 @@ public class DocumentCollectionTest {
         assertEquals(2, docs.get(0).getSection(0).getParagraph(0).getNumberOfSentences());
         assertEquals("sentence00", docs.get(0).getSection(0).getParagraph(0).getSentence(0).content);
         assertEquals(true, docs.get(0).getSection(0).getParagraph(0).getSentence(0).isFirstSentence);
-        assertEquals(0, docs.get(0).getSection(0).getParagraph(0).getSentence(0).position);
+        assertEquals(0, docs.get(0).getSection(0).getParagraph(0).getSentence(0).lineNum);
         assertEquals("sentence01", docs.get(0).getSection(0).getParagraph(0).getSentence(1).content);
         assertEquals(false, docs.get(0).getSection(0).getParagraph(0).getSentence(1).isFirstSentence);
-        assertEquals(1, docs.get(0).getSection(0).getParagraph(0).getSentence(1).position);
+        assertEquals(1, docs.get(0).getSection(0).getParagraph(0).getSentence(1).lineNum);
 
         // second document
         assertEquals(1, docs.get(1).size());
@@ -80,9 +80,9 @@ public class DocumentCollectionTest {
         assertEquals(2, docs.get(1).getSection(0).getParagraph(0).getNumberOfSentences());
         assertEquals("sentence10", docs.get(1).getSection(0).getParagraph(0).getSentence(0).content);
         assertEquals(true, docs.get(1).getSection(0).getParagraph(0).getSentence(0).isFirstSentence);
-        assertEquals(0, docs.get(1).getSection(0).getParagraph(0).getSentence(0).position);
+        assertEquals(0, docs.get(1).getSection(0).getParagraph(0).getSentence(0).lineNum);
         assertEquals("sentence11", docs.get(1).getSection(0).getParagraph(0).getSentence(1).content);
         assertEquals(false, docs.get(1).getSection(0).getParagraph(0).getSentence(1).isFirstSentence);
-        assertEquals(1, docs.get(1).getSection(0).getParagraph(0).getSentence(1).position);
+        assertEquals(1, docs.get(1).getSection(0).getParagraph(0).getSentence(1).lineNum);
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/model/DocumentTest.java
+++ b/redpen-core/src/test/java/cc/redpen/model/DocumentTest.java
@@ -37,10 +37,10 @@ public class DocumentTest {
         assertEquals(1, doc.getSection(0).getNumberOfParagraphs());
         assertEquals("sentence0", doc.getSection(0).getParagraph(0).getSentence(0).content);
         assertEquals(true, doc.getSection(0).getParagraph(0).getSentence(0).isFirstSentence);
-        assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).position);
+        assertEquals(0, doc.getSection(0).getParagraph(0).getSentence(0).lineNum);
         assertEquals("sentence1", doc.getSection(0).getParagraph(0).getSentence(1).content);
         assertEquals(false, doc.getSection(0).getParagraph(0).getSentence(1).isFirstSentence);
-        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).position);
+        assertEquals(1, doc.getSection(0).getParagraph(0).getSentence(1).lineNum);
         assertEquals(1, doc.getSection(0).getNumberOfLists());
         assertEquals(3, doc.getSection(0).getListBlock(0).getNumberOfListElements());
         assertEquals(0, doc.getSection(0).getListBlock(0).getListElement(0).getLevel());

--- a/redpen-core/src/test/java/cc/redpen/model/SectionTest.java
+++ b/redpen-core/src/test/java/cc/redpen/model/SectionTest.java
@@ -29,7 +29,7 @@ public class SectionTest {
     public void testGetJoinedHeaderFromSectionHasOneSentenceHeader() {
         Section section = new Section(0, "header");
         assertEquals("header", section.getJoinedHeaderContents().content);
-        assertEquals(0, section.getJoinedHeaderContents().position);
+        assertEquals(0, section.getJoinedHeaderContents().lineNum);
     }
 
     @Test
@@ -39,13 +39,13 @@ public class SectionTest {
         headers.add(new Sentence("header2.", 0));
         Section section = new Section(0, headers);
         assertEquals("header1. header2.", section.getJoinedHeaderContents().content);
-        assertEquals(0, section.getJoinedHeaderContents().position);
+        assertEquals(0, section.getJoinedHeaderContents().lineNum);
     }
 
     @Test
     public void testGetJoinedHeaderFromSectionWithoutHeader() {
         Section section = new Section(0);
         assertEquals("", section.getJoinedHeaderContents().content);
-        assertEquals(0, section.getJoinedHeaderContents().position);
+        assertEquals(0, section.getJoinedHeaderContents().lineNum);
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/parser/LineOffsetTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/LineOffsetTest.java
@@ -1,0 +1,47 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (C) 2014 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cc.redpen.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LineOffsetTest {
+    @Test
+    public void testCompareToDifferentOffset() {
+        LineOffset offsetOne = new LineOffset(1, 1);
+        LineOffset offsetTwo = new LineOffset(1, 2);
+        assertTrue(offsetOne.compareTo(offsetTwo) < 0);
+        assertTrue(offsetTwo.compareTo(offsetOne) > 0);
+    }
+
+    @Test
+    public void testCompareToDifferentLineNum() {
+        LineOffset offsetOne = new LineOffset(1, 1);
+        LineOffset offsetTwo = new LineOffset(2, 1);
+        assertTrue(offsetOne.compareTo(offsetTwo) < 0);
+        assertTrue(offsetTwo.compareTo(offsetOne) > 0);
+    }
+
+    @Test
+    public void testCompareToSameOffset() {
+        LineOffset offsetOne = new LineOffset(1, 1);
+        LineOffset offsetTwo = new LineOffset(1, 1);
+        assertTrue(offsetOne.compareTo(offsetTwo) == 0);
+    }
+}

--- a/redpen-core/src/test/java/cc/redpen/parser/markdown/MergedCandidateSentenceTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/markdown/MergedCandidateSentenceTest.java
@@ -5,7 +5,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class MergedCandidateSentenceTest {
@@ -16,7 +18,8 @@ public class MergedCandidateSentenceTest {
                 new CandidateSentence(1, "second ", "", 6),
                 new CandidateSentence(1, "third", "", 13));
 
-        MergedCandidateSentence mergedSentence = MergedCandidateSentence.merge(candidateSentences);
+        MergedCandidateSentence mergedSentence = MergedCandidateSentence.merge(candidateSentences).get();
+        assertTrue(mergedSentence != null);
         assertEquals("first second third", mergedSentence.getContents());
         List<LineOffset> expectedOffsets = initializeMappingTable(
                 new LineOffset(1, 0), // f

--- a/redpen-core/src/test/java/cc/redpen/parser/markdown/MergedCandidateSentenceTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/markdown/MergedCandidateSentenceTest.java
@@ -1,0 +1,64 @@
+package cc.redpen.parser.markdown;
+
+import cc.redpen.parser.LineOffset;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MergedCandidateSentenceTest {
+    @Test
+    public void testMerge() {
+        List<CandidateSentence> candidateSentences = initializeCandidateSentences(
+                new CandidateSentence(1, "first ", "", 0),
+                new CandidateSentence(1, "second ", "", 6),
+                new CandidateSentence(1, "third", "", 13));
+
+        MergedCandidateSentence mergedSentence = MergedCandidateSentence.merge(candidateSentences);
+        assertEquals("first second third", mergedSentence.getContents());
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(1, 0), // f
+                new LineOffset(1, 1), // i
+                new LineOffset(1, 2), // r
+                new LineOffset(1, 3), // s
+                new LineOffset(1, 4), // t
+                new LineOffset(1, 5), // ' '
+                new LineOffset(1, 6), // s
+                new LineOffset(1, 7), // e
+                new LineOffset(1, 8), // c
+                new LineOffset(1, 9), // o
+                new LineOffset(1, 10), // n
+                new LineOffset(1, 11), // d
+                new LineOffset(1, 12), // ' '
+                new LineOffset(1, 13), // t
+                new LineOffset(1, 14), // h
+                new LineOffset(1, 15), // i
+                new LineOffset(1, 16), // r
+                new LineOffset(1, 17)); // d
+
+        assertEquals(expectedOffsets.size(), mergedSentence.getOffsetMap().size());
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i),
+                    mergedSentence.getOffsetMap().get(i));
+        }
+
+    }
+
+    private static List<CandidateSentence> initializeCandidateSentences(CandidateSentence... candidateSentences) {
+        List<CandidateSentence> candidateSentenceList = new ArrayList<>();
+        for (CandidateSentence candidateSentence : candidateSentences) {
+            candidateSentenceList.add(candidateSentence);
+        }
+        return candidateSentenceList;
+    }
+
+    private static List<LineOffset> initializeMappingTable(LineOffset... offsets) {
+        List<LineOffset> offsetTable = new ArrayList<>();
+        for (LineOffset offset : offsets) {
+            offsetTable.add(offset);
+        }
+        return offsetTable;
+    }
+}


### PR DESCRIPTION
Support line offset.

For example, given follwoing lines,  

* ito
  * kato

The offset of first line is 2 and the offset of second line is 4.