### PR TITLE
Bump redpen cli version to 1.1

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -46,7 +46,7 @@ public final class Main {
 
     private static final String PROGRAM = "redpen-cli";
 
-    private static final String VERSION = "1.0.1";
+    private static final String VERSION = "1.1";
 
     private static final int EDEFAULT_LIMIT = 1;
 


### PR DESCRIPTION
I will change cli version to 1.1 from 1.0.1 since the RedPen output formats are going to be changed by issues such as #374 and #369.