### PR TITLE
Fix bug on line inconsistency in markdown parser

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -343,8 +343,9 @@ public class ToFileContentSerializer implements Visitor {
         switch (simpleNode.getType()) {
             case Linebreak:
                 addCandidateSentence(
-                        getLineNumberFromStartIndex(simpleNode.getStartIndex()),
-                        " ", simpleNode.getStartIndex() - getLineStartIndex(lineNumber));
+                        getLineNumberFromStartIndex(simpleNode.getStartIndex()+1),
+                        " ", 0); //NOTE: column Offset of Linebreak should be always 0.
+                break;
             case Nbsp:
                 break;
             case HRule:

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -130,6 +130,32 @@ public class MarkdownParserTest {
     }
 
     @Test
+    public void testGenerateDocumentWithHeaderedDocument() {
+        String sampleText = "# Validator\n"
+        + "Validator class is a abstract class in RedPen project.\n"
+        + "Functions provided by RedPen class are implemented with validator class.\n";
+        Document doc = createFileContent(sampleText);
+
+        final Section secondSection = doc.getSection(1);
+        assertEquals(1, secondSection.getHeaderContentsListSize());
+        assertEquals("Validator", secondSection.getHeaderContent(0).getContent());
+        assertEquals(1, secondSection.getHeaderContent(0).getLineNum());
+        assertEquals(2, secondSection.getHeaderContent(0).getStartPositionOffset());
+        assertEquals(0, secondSection.getNumberOfLists());
+        assertEquals(1, secondSection.getNumberOfParagraphs());
+
+        // validate paragraph in 2nd section
+        assertEquals(2, secondSection.getParagraph(0).getNumberOfSentences());
+        assertEquals(true, secondSection.getParagraph(0).getSentence(0).isFirstSentence());
+        assertEquals(2, secondSection.getParagraph(0).getSentence(0).getLineNum());
+        assertEquals(0, secondSection.getParagraph(0).getSentence(0).getStartPositionOffset());
+        assertEquals(false, secondSection.getParagraph(0).getSentence(1).isFirstSentence());
+        assertEquals(3, secondSection.getParagraph(0).getSentence(1).getLineNum());
+        assertEquals(0, secondSection.getParagraph(0).getSentence(1).getStartPositionOffset());
+    }
+
+
+    @Test
     public void testGenerateDocumentWithList() {
         String sampleText =
                 "Threre are several railway companies in Japan as follows.\n";

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -149,11 +149,26 @@ public class MarkdownParserTest {
         assertEquals(true, secondSection.getParagraph(0).getSentence(0).isFirstSentence());
         assertEquals(2, secondSection.getParagraph(0).getSentence(0).getLineNum());
         assertEquals(0, secondSection.getParagraph(0).getSentence(0).getStartPositionOffset());
+        assertEquals("Validator class is a abstract class in RedPen project.",
+                secondSection.getParagraph(0).getSentence(0).getContent());
+
         assertEquals(false, secondSection.getParagraph(0).getSentence(1).isFirstSentence());
+        assertEquals(" Functions provided by RedPen class are implemented with validator class.",
+                secondSection.getParagraph(0).getSentence(1).getContent());
         assertEquals(3, secondSection.getParagraph(0).getSentence(1).getLineNum());
         assertEquals(0, secondSection.getParagraph(0).getSentence(1).getStartPositionOffset());
-    }
 
+        // NOTE: both linebreak and first character of the offsets are 0
+        List<LineOffset> expectedOffsets = initializeMappingTable(
+                new LineOffset(3, 0), // LineBreak NOTE: lineBreak is exist but the offset is "0"
+                new LineOffset(3, 0), // F NOTE: even when there is a Linebreak, sentence start from offset "0".
+                new LineOffset(3, 1)  // u
+        );
+        for (int i = 0; i < expectedOffsets.size() ; i++) {
+            assertEquals(expectedOffsets.get(i), secondSection.getParagraph(0).getSentence(1).getOffset(i).get());
+        }
+
+    }
 
     @Test
     public void testGenerateDocumentWithList() {


### PR DESCRIPTION
When markdown parser in redpen 1.1 experimental has the  following input document, the computed line number is wrong... 

    # Validator
    Validator class is a abstract class in RedPen project.
    Functions provided by RedPen class are implemented with validator class.

