### PR TITLE
Changes for the web demo GUI

### DIFF
--- a/redpen-cli/src/main/java/cc/redpen/Main.java
+++ b/redpen-cli/src/main/java/cc/redpen/Main.java
@@ -17,20 +17,11 @@
  */
 package cc.redpen;
 
-import cc.redpen.formatter.Formatter;
-import cc.redpen.formatter.JSONFormatter;
-import cc.redpen.formatter.PlainFormatter;
-import cc.redpen.formatter.XMLFormatter;
+import cc.redpen.formatter.*;
 import cc.redpen.model.Document;
 import cc.redpen.parser.DocumentParser;
 import cc.redpen.validator.ValidationError;
-import org.apache.commons.cli.BasicParser;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.OptionBuilder;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,11 +139,17 @@ public final class Main {
             case "plain":
                 formatter = new PlainFormatter();
                 break;
+            case "plain2":
+                formatter = new PlainBySentenceFormatter();
+                break;
             case "json":
                 formatter = new JSONFormatter();
                 break;
+            case "json2":
+                formatter = new JSONBySentenceFormatter();
+                break;
             default:
-                LOG.error("Unsupported format:" + resultFormat);
+                LOG.error("Unsupported format: " + resultFormat + " - please use xml, plain, plain2, json or json2");
                 return -1;
         }
 

--- a/redpen-core/src/main/java/cc/redpen/formatter/Formatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/Formatter.java
@@ -33,17 +33,50 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * ResultDistributor flush the errors reported from Validators.
+ * Formatter - Format and write RedPen errors
  */
 public abstract class Formatter {
     private static final Logger LOG = LoggerFactory.getLogger(Formatter.class);
 
-    public abstract void format(PrintWriter pw, Map<Document, List<ValidationError>> docErrorsMap) throws RedPenException, IOException;
 
-    public void format(OutputStream os, Map<Document, List<ValidationError>> docErrorsMap) throws RedPenException, IOException {
-        format(new PrintWriter(os), docErrorsMap);
+    /**
+     * Format and print the errors for a set of documents
+     *
+     * @param printWriter  The printwriter destination for the errors
+     * @param docErrorsMap a map of documents to the corresponding list of errors
+     * @throws RedPenException
+     * @throws IOException
+     */
+    public abstract void format(PrintWriter printWriter, Map<Document, List<ValidationError>> docErrorsMap) throws RedPenException, IOException;
+
+    /**
+     * Format a single error as a string
+     *
+     * @param document the document the error is for
+     * @param error    the error to format
+     * @return A formatted error
+     * @throws RedPenException
+     */
+    public abstract String formatError(Document document, ValidationError error) throws RedPenException;
+
+    /**
+     * Format and print the errors for a set of documents
+     *
+     * @param outputStream the output stream destination for the errors
+     * @param docErrorsMap a map of documents to the corresponding list of errors
+     * @throws RedPenException
+     * @throws IOException
+     */
+    public void format(OutputStream outputStream, Map<Document, List<ValidationError>> docErrorsMap) throws RedPenException, IOException {
+        format(new PrintWriter(outputStream), docErrorsMap);
     }
 
+    /**
+     * Format errors for a set of documents as a String
+     *
+     * @param docErrorsMap a map of documents to the corresponding list of errors
+     * @return appropriately formatted errors per document
+     */
     public String format(Map<Document, List<ValidationError>> docErrorsMap) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
@@ -55,6 +88,13 @@ public abstract class Formatter {
         return new String(baos.toByteArray(), StandardCharsets.UTF_8);
     }
 
+    /**
+     * Format the errors for a given document
+     *
+     * @param document the document
+     * @param errors   the list of errors for the document
+     * @return an appropriately formatted group of errors for the document
+     */
     public String format(Document document, List<ValidationError> errors) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Map<Document, List<ValidationError>> docErrorsMap = new HashMap<>();

--- a/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
@@ -1,0 +1,115 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cc.redpen.formatter;
+
+import cc.redpen.model.Document;
+import cc.redpen.model.Sentence;
+import cc.redpen.validator.ValidationError;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * JSON error formatter, collating errors by sentence
+ */
+public class JSONBySentenceFormatter extends JSONFormatter {
+    private static final Logger LOG = LoggerFactory.getLogger(JSONBySentenceFormatter.class);
+
+    /**
+     * Reusable comparator to compare errors by their position in the document, starting with the line number, followed by the offset within the line, and finally the sentence content
+     */
+    public static final Comparator<ValidationError> BY_SENTENCE_COMPARATOR = new Comparator<ValidationError>() {
+        @Override
+        public int compare(ValidationError error1, ValidationError error2) {
+            if ((error1 == null) || (error2 == null)) {
+                return -1;
+            }
+            Sentence sentence1 = error1.getSentence();
+            Sentence sentence2 = error2.getSentence();
+            int lineComp = sentence1.getLineNumber() - sentence2.getLineNumber();
+            if (lineComp == 0) {
+                int offsetComp = sentence1.getStartPositionOffset() - sentence2.getStartPositionOffset();
+                if (offsetComp == 0) {
+                    return sentence1.getContent().compareTo(sentence2.getContent());
+                }
+                return offsetComp;
+            }
+            return lineComp;
+        }
+    };
+
+    /**
+     * Render a single redpen error as JSON
+     *
+     * @param error the redpen error
+     * @return a JSON object representing the redpen error
+     * @throws org.json.JSONException
+     */
+    @Override
+    protected JSONObject asJSON(ValidationError error) throws JSONException {
+        JSONObject jsonError = super.asJSON(error);
+        jsonError.remove("sentence");
+        return jsonError;
+    }
+
+    /**
+     * Render as a JSON object a list of errors for a given document
+     *
+     * @param document the document that has the errors
+     * @param errors   a list of errors
+     * @return a JSON object representing the errors
+     */
+    protected JSONObject asJSON(Document document, List<ValidationError> errors) {
+        List<ValidationError> sortedErrors = new ArrayList<>(errors);
+        sortedErrors.sort(BY_SENTENCE_COMPARATOR);
+
+        JSONObject jsonErrors = new JSONObject();
+        try {
+            if (document.getFileName().isPresent()) {
+                jsonErrors.put("document", document.getFileName().get());
+            }
+            JSONArray documentErrors = new JSONArray();
+            jsonErrors.put("errors", documentErrors);
+
+            JSONArray sentenceErrors = new JSONArray();
+            ValidationError lastError = null;
+            for (ValidationError error : sortedErrors) {
+                if (BY_SENTENCE_COMPARATOR.compare(lastError, error) != 0) {
+                    JSONObject sentenceError = new JSONObject();
+                    sentenceError.put("sentence", error.getSentence().getContent());
+                    sentenceError.put("lineNum", error.getSentence().getLineNumber());
+                    sentenceError.put("offset", error.getSentence().getStartPositionOffset());
+                    sentenceErrors = new JSONArray();
+                    sentenceError.put("errors", sentenceErrors);
+                    documentErrors.put(sentenceError);
+                    lastError = error;
+                }
+                sentenceErrors.put(asJSON(error));
+            }
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonErrors;
+    }
+}

--- a/redpen-core/src/main/java/cc/redpen/formatter/XMLFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/XMLFormatter.java
@@ -47,8 +47,8 @@ import java.util.Map;
  * XML Output formatter.
  */
 public class XMLFormatter extends Formatter {
-
     private static final Logger LOG = LoggerFactory.getLogger(XMLFormatter.class);
+
     private DocumentBuilder db;
     private final Transformer transformer;
 
@@ -78,14 +78,15 @@ public class XMLFormatter extends Formatter {
         for (cc.redpen.model.Document document : docErrorsMap.keySet()) {
             List<ValidationError> errors = docErrorsMap.get(document);
             for (ValidationError error : errors) {
-                writer.write(writeError(document, error));
+                writer.write(formatError(document, error));
             }
         }
         writer.write("</validation-result>");
         writer.flush();
     }
 
-    private String writeError(cc.redpen.model.Document document, ValidationError error) throws RedPenException {
+    @Override
+    public String formatError(cc.redpen.model.Document document, ValidationError error) throws RedPenException {
         // create dom
         Document doc = db.newDocument();
         Element errorElement = doc.createElement("error");

--- a/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 /**
  * Parser for plain text file.
  */
-final class PlainTextParser extends BaseDocumentParser implements Serializable{
+final class PlainTextParser extends BaseDocumentParser implements Serializable {
     private static final Logger LOG =
             LoggerFactory.getLogger(PlainTextParser.class);
     private static final long serialVersionUID = -4343255148183552844L;
@@ -84,14 +84,16 @@ final class PlainTextParser extends BaseDocumentParser implements Serializable{
     }
 
     private String extractSentences(int lineNum, String line, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
+        int offset = 0;
         int periodPosition = sentenceExtractor.getSentenceEndPosition(line);
         if (periodPosition == -1) {
             return line;
         } else {
             while (true) {
-                builder.addSentence(
-                        line.substring(0, periodPosition + 1), lineNum);
-                line = line.substring(periodPosition + 1, line.length());
+                Sentence sentence = new Sentence(line.substring(0, periodPosition + 1), lineNum, offset);
+                builder.addSentence(sentence);
+                offset = periodPosition + 1;
+                line = line.substring(offset, line.length());
                 periodPosition = sentenceExtractor.getSentenceEndPosition(line);
                 if (periodPosition == -1) {
                     return line;

--- a/redpen-core/src/test/java/cc/redpen/formatter/JSONFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/JSONFormatterTest.java
@@ -112,8 +112,10 @@ public class JSONFormatterTest extends Validator {
         assertEquals(1, jsonErrors.length());
         assertEquals(sampleText, jsonErrors.getJSONObject(0).getString("sentence"));
         assertEquals("0", jsonErrors.getJSONObject(0).getString("sentenceStartColumnNum"));
-        assertEquals("1,18", jsonErrors.getJSONObject(0).getString("errorStartPosition"));
-        assertEquals("1,19", jsonErrors.getJSONObject(0).getString("errorEndPosition"));
+        assertEquals("1", jsonErrors.getJSONObject(0).getJSONObject("startPosition").getString("lineNum"));
+        assertEquals("18", jsonErrors.getJSONObject(0).getJSONObject("startPosition").getString("offset"));
+        assertEquals("1", jsonErrors.getJSONObject(0).getJSONObject("endPosition").getString("lineNum"));
+        assertEquals("19", jsonErrors.getJSONObject(0).getJSONObject("endPosition").getString("offset"));
     }
 
 }

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenConfigurationResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenConfigurationResource.java
@@ -34,7 +34,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
-import java.util.function.BiConsumer;
 
 /**
  * Resource to get and set RedPen configuration options.
@@ -64,27 +63,24 @@ public class RedPenConfigurationResource {
             Map<String, RedPen> redpens = new RedPenService(context).getRedPens();
             final JSONObject redpensJSON = new JSONObject();
             response.put("redpens", redpensJSON);
-            redpens.forEach(new BiConsumer<String, RedPen>() {
-                @Override
-                public void accept(String configurationName, RedPen redPen) {
-                    if ((lang == null) || lang.isEmpty() || redPen.getConfiguration().getLang().contains(lang)) {
-                        try {
-                            // add specific configuration items
-                            JSONObject config = new JSONObject();
-                            config.put("lang", redPen.getConfiguration().getLang());
-                            config.put("tokenizer", redPen.getConfiguration().getTokenizer().getClass().getName());
+            redpens.forEach((configurationName, redPen) -> {
+                if ((lang == null) || lang.isEmpty() || redPen.getConfiguration().getLang().contains(lang)) {
+                    try {
+                        // add specific configuration items
+                        JSONObject config = new JSONObject();
+                        config.put("lang", redPen.getConfiguration().getLang());
+                        config.put("tokenizer", redPen.getConfiguration().getTokenizer().getClass().getName());
 
-                            // add the names of the validators
-                            JSONArray validatorConfigs = new JSONArray();
-                            for (ValidatorConfiguration validator : redPen.getConfiguration().getValidatorConfigs()) {
-                                validatorConfigs.put(validator.getConfigurationName());
-                            }
-                            config.put("validators", validatorConfigs);
-
-                            redpensJSON.put(configurationName, config);
-                        } catch (Exception e) {
-                            LOG.error("Exception when rendering RedPen to JSON for configuration " + configurationName, e);
+                        // add the names of the validators
+                        JSONArray validatorConfigs = new JSONArray();
+                        for (ValidatorConfiguration validator : redPen.getConfiguration().getValidatorConfigs()) {
+                            validatorConfigs.put(validator.getConfigurationName());
                         }
+                        config.put("validators", validatorConfigs);
+
+                        redpensJSON.put(configurationName, config);
+                    } catch (Exception e) {
+                        LOG.error("Exception when rendering RedPen to JSON for configuration " + configurationName, e);
                     }
                 }
             });

--- a/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/RedPenResource.java
@@ -20,14 +20,12 @@ package cc.redpen.server.api;
 
 import cc.redpen.RedPen;
 import cc.redpen.RedPenException;
+import cc.redpen.formatter.JSONBySentenceFormatter;
 import cc.redpen.formatter.JSONFormatter;
 import cc.redpen.model.Document;
-import cc.redpen.model.Sentence;
 import cc.redpen.parser.DocumentParser;
 import cc.redpen.validator.ValidationError;
 import org.apache.wink.common.annotations.Workspace;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +34,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -84,58 +81,7 @@ public class RedPenResource {
         Document parsedDocument = redPen.parse(DocumentParser.of(documentParser), document);
         List<ValidationError> errors = redPen.validate(parsedDocument);
 
-        // Perhaps in the future this inversion can be done by the formatter?
-
-        // Sort the errors by line number, then position offset, then sentence content
-        errors.sort(new Comparator<ValidationError>() {
-            @Override
-            public int compare(ValidationError error1, ValidationError error2) {
-                Sentence sentence1 = error1.getSentence();
-                Sentence sentence2 = error2.getSentence();
-                int lineComp = sentence1.getLineNumber() - sentence2.getLineNumber();
-                if (lineComp == 0) {
-                    int positionComp = sentence1.getStartPositionOffset() - sentence2.getStartPositionOffset();
-                    if (positionComp == 0) {
-                        return sentence1.getContent().compareTo(sentence2.getContent());
-                    }
-                    return positionComp;
-                }
-                return lineComp;
-            }
-        });
-
-        JSONObject response = new JSONObject();
-
-        // collate the errors by sentence in line/position order
-        try {
-            JSONArray responses = new JSONArray();
-            response.put("errors", responses);
-            JSONArray errorDetails = null;
-            String lastSentenceContent = null;
-            for (ValidationError error : errors) {
-                if ((errorDetails == null) || !error.getSentence().getContent().equals(lastSentenceContent)) {
-                    lastSentenceContent = error.getSentence().getContent();
-                    errorDetails = new JSONArray();
-                    JSONObject errorHeader = new JSONObject();
-
-                    errorHeader.put("sentence", lastSentenceContent);
-                    errorHeader.put("errors", errorDetails);
-                    errorHeader.put("lineNum", error.getLineNumber());
-                    responses.put(errorHeader);
-                }
-                JSONObject errorItem = new JSONObject();
-
-                // these names should be consistent with those in JSONFormatter - perhaps we need to expose a formatter for an error?
-                errorItem.put("message", error.getMessage());
-                errorItem.put("errorStart", error.getStartPosition().isPresent() ? error.getStartPosition().get().offset : 0);
-                errorItem.put("errorEnd", error.getEndPosition().isPresent() ? error.getEndPosition().get().offset : 0);
-                errorItem.put("validator", error.getValidatorName());
-                errorDetails.put(errorItem);
-            }
-        } catch (Exception e) {
-            LOG.error("Exception when creating JSON response", e);
-        }
-
-        return Response.ok().entity(response).build();
+        String responseJSON = new JSONBySentenceFormatter().format(parsedDocument, errors);
+        return Response.ok().entity(responseJSON).build();
     }
 }

--- a/redpen-server/src/main/java/cc/redpen/server/api/WinkAPIDescriber.java
+++ b/redpen-server/src/main/java/cc/redpen/server/api/WinkAPIDescriber.java
@@ -42,10 +42,10 @@ public class WinkAPIDescriber {
         sb.append("<head>\n");
         sb.append("<title>REST API Description</title>\n");
         sb.append("<style>\n");
-        sb.append("table {font:1em Verdana, Arial, Helvetica, sans-serif; border-collapse: collapse; }");
-        sb.append("th { padding: 0.5em; padding-top: 2em; text-align: left; border-bottom: 1px solid #eee;}");
-        sb.append("tr, td { border-bottom: 1px dotted #fafafa;}");
-        sb.append("td { border-bottom: 1px dotted #f0f0f0; padding: 0.5em 0.5em; background-color: #fefefe }");
+        sb.append("table {font:0.75em Verdana, Arial, Helvetica, sans-serif; line-height:0.75em; border-collapse: collapse; }");
+        sb.append("th {padding: 0.5em; padding-top: 2em; text-align: left; border:none;}");
+        sb.append("tr, td {border-bottom: 1px dotted #fafafa;}");
+        sb.append("td {vertical-align:top;border:none; padding: 0.5em 0.5em; background-color: #fefefe }");
         sb.append("</style>\n");
         sb.append("</head>\n");
         sb.append("<body>\n");
@@ -124,7 +124,6 @@ public class WinkAPIDescriber {
                                             }
                                         }
                                     }
-                                    sb.append(" ");
                                 } else if (annotation instanceof FormParam) {
                                     FormParam param = (FormParam) annotation;
                                     sb.append(param.value());
@@ -137,10 +136,10 @@ public class WinkAPIDescriber {
                                             }
                                         }
                                     }
-                                    sb.append(" ");
                                 } else if (annotation instanceof Context) {
                                     sb.append("name=value...");
                                 }
+                                sb.append("<br/>");
                             }
                         }
                         sb.append("</td>");

--- a/redpen-server/src/main/webapp/css/redpen.css
+++ b/redpen-server/src/main/webapp/css/redpen.css
@@ -1,4 +1,21 @@
-/* colours to match redpen theme from redpen.cc */
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 body {
     background-color: #c0c5b2;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -102,6 +119,10 @@ textarea {
 
 .redpen-fixed-row>div {
     height: 100%;
+}
+
+.redpen-error-section {
+    cursor: help;
 }
 
 .redpen-error-sentence {

--- a/redpen-server/src/main/webapp/index.html
+++ b/redpen-server/src/main/webapp/index.html
@@ -20,6 +20,24 @@
 
 <script>
 
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // some sample documents and the parser to use to parse them
 var sampleDocuments = {
     en: {parser: "PLAIN", document: "Some software tools work in more than one machine, and such distributed (cluster)systems can handle huge data or tasks, because such software tools make use of large amount of computer resources.\n" +
@@ -29,7 +47,7 @@ var sampleDocuments = {
             "本稿では,複数の計算機（クラスタ）でで動作する各サーバーを「インスタンス」と呼びまます。\n" +
             "たとえば検索エンジンやデータベースではインデックスを複数のインスタンスで分割して保持します。\n" +
             "このような場合、各インデクスの結果をマージしてclientプログラムに渡す機構が必要となります。"},
-    en_md: { parser: "MARKDOWN", document: "# Instances\n" +
+    en_md: {parser: "MARKDOWN", document: "# Instances\n" +
             "Some software tools work in more than one machine, and such _distributed_ (cluster)systems can handle huge data or tasks, because such software tools make use of large amount of computer resources, such as\n" +
             "* CPU\n* Disk\n* Memory\n\n" +
             "In this article, we'll call a computer server that works as a member of a cluster an _instance_. for example, each instance in distributed search engines stores the the fractions of data." +
@@ -51,11 +69,17 @@ function clearResult() {
 
 // paste some sample text into the editor and trigger a change
 function pasteSampleText(key) {
+    var text;
     if (sampleDocuments[key]) {
         permitLanguageAutoDetect = true;
+        text = sampleDocuments[key].document;
         $("#redpen-document-parser").val(sampleDocuments[key].parser);
-        $("#redpen-editor").val(sampleDocuments[key].document).trigger("change");
     }
+    $("#redpen-editor")
+            .val(text ? text : "")
+            .trigger("change")
+            .prop("disabled", false)
+            .prop("placeholder", "Please type or paste some text here...");
 }
 
 $(document).ready(function () {
@@ -143,6 +167,34 @@ $(document).ready(function () {
             showConfigurationOptions(firstValidRedpen);
         };
 
+        // highlight a line in the editor
+        var highlightEditor = function (error) {
+            if (error) {
+                var document = $(editor).val();
+                var start;
+                var end;
+
+                start = document.indexOf(error.sentence);
+                end = start + error.sentence.length;
+                if (start < 0) {
+                    start = document.length;
+                    end = start;
+                }
+                var textarea = $(editor)[0];
+
+                if (textarea.setSelectionRange) {
+                    textarea.focus();
+                    textarea.setSelectionRange(start, end);
+                } else if (textarea.createTextRange) {
+                    var range = textarea.createTextRange();
+                    range.collapse(true);
+                    range.moveEnd('character', end);
+                    range.moveStart('character', start);
+                    range.select();
+                }
+            }
+        };
+
         // call RedPen to validate the document and display any errors
         var validateDocument = function () {
             redpen.validateBySentence(
@@ -168,29 +220,40 @@ $(document).ready(function () {
                                             .html('<span class="redpen-red">Red</span>Pen found the following errors:')
                                     );
 
-                            for (var i = 0; i < errors.length; i++) {
-                                var errorDiv = $('<div></div>');
+                            var addError = function (error) {
+                                var errorDiv = $('<div></div>')
+                                        .addClass('redpen-error-section')
+                                        .mouseenter(function () {
+                                            highlightEditor(error);
+                                        })
+                                        .mouseleave(function () {
+                                            highlightEditor(false);
+                                        });
                                 var errorList = $('<ul></ul>');
                                 results.append(errorDiv);
                                 $(errorDiv)
                                         .append($('<p></p>')
                                                 .addClass('redpen-error-sentence')
-                                                .html(errors[i].sentence)
+                                                .html(error.sentence)
                                         )
                                         .append(errorList);
 
-                                for (var j = 0; j < errors[i].errors.length; j++) {
-                                    if (validators[errors[i].errors[j].validator]) {
+                                for (var j = 0; j < error.errors.length; j++) {
+                                    if (validators[error.errors[j].validator]) {
                                         $(errorList).append($('<li></li>')
                                                 .addClass('redpen-error-message')
-                                                .append(errors[i].errors[j].message)
+                                                .append(error.errors[j].message)
                                                 .append($("<div></div>")
                                                         .addClass('redpen-error-validator')
-                                                        .text(errors[i].errors[j].validator)
+                                                        .text(error.errors[j].validator)
                                                 )
                                         )
                                     }
                                 }
+                            };
+                            for (var i = 0; i < errors.length; i++) {
+                                addError(errors[i]);
+
                             }
                         }
                         else {
@@ -247,7 +310,8 @@ $(document).ready(function () {
         setLanguage("en");
         pasteSampleText("en");
     });
-});
+})
+;
 </script>
 </head>
 <body>
@@ -293,12 +357,12 @@ $(document).ready(function () {
         <h1>Welcome to <span class="redpen-red">Red</span>Pen!</h1>
 
         <p>To try the <span class="redpen-red">Red</span>Pen validator, please type or paste some text into
-            the left-hand box.</p>
+            the first box.</p>
 
         <div class="row redpen-fixed-row">
             <div class="col-md-5">
-                <textarea id="redpen-editor" class="form-control" autofocus
-                          placeholder="Type or paste a document here..."></textarea>
+                <textarea disabled id="redpen-editor" class="form-control" autofocus
+                          placeholder="Please wait..."></textarea>
                 <button type="button" class="btn btn-sm redpen-clear-button" onclick="clearResult()">Clear</button>
             </div>
             <div class="col-md-5">


### PR DESCRIPTION
* Moved the "by sentence" formatter from the web server to an Formatter implementation (JSONBySentenceFormatter)
* Created a "by sentence" plain formatter (PlainBySentenceFormatter)
* Added the new formatters as redpen-cli output options json2 and plain2
* Modified PlainTextParser to add the offset within each line each Sentence appears to assist sorting errors by their position within a document
* Added a comment or two
* Added primitive sentence highlighting in the editor of the erroneous sentence on mouse-over