### PR TITLE
Support for offsets in plain text documents

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
@@ -120,10 +120,9 @@ public class JSONBySentenceFormatter extends JSONFormatter {
                     JSONObject sentenceError = new JSONObject();
                     sentenceError.put("sentence", error.getSentence().getContent());
                     Sentence sentence = error.getSentence();
-                    //NOTE: last position is optional (only Markdown parser provides the offset positions)
-                    LineOffset lastPosition = sentence.getOffset(sentence.getContent().length()-1).orElse(
-                            new LineOffset(sentence.getLineNumber(),
-                                    sentence.getStartPositionOffset()+sentence.getContent().length()));
+                    //NOTE: last position is optional
+                    LineOffset lastPosition = sentence.getOffset(sentence.getContent().length() - 1)
+                            .orElse(new LineOffset(sentence.getLineNumber(), sentence.getStartPositionOffset() + sentence.getContent().length()));
                     sentenceError.put("position", asJSON(
                             sentence.getLineNumber(),
                             sentence.getStartPositionOffset(),

--- a/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
@@ -88,6 +88,9 @@ public class JSONBySentenceFormatter extends JSONFormatter {
         }
         jsonError.put("position", asJSON(startOffset, endOffset));
 
+        // add the error position relative to the sentence's content
+        jsonError.put("subsentence", asJSON(error.getSentence(), startOffset, endOffset));
+
         return jsonError;
     }
 

--- a/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/JSONBySentenceFormatter.java
@@ -123,6 +123,7 @@ public class JSONBySentenceFormatter extends JSONFormatter {
                             error.getSentence().getContent().length() + error.getSentence().getStartPositionOffset()));
                     sentenceErrors = new JSONArray();
                     sentenceError.put("errors", sentenceErrors);
+
                     documentErrors.put(sentenceError);
                     lastError = error;
                 }

--- a/redpen-core/src/main/java/cc/redpen/formatter/JSONFormatter.java
+++ b/redpen-core/src/main/java/cc/redpen/formatter/JSONFormatter.java
@@ -19,6 +19,7 @@ package cc.redpen.formatter;
 
 import cc.redpen.RedPenException;
 import cc.redpen.model.Document;
+import cc.redpen.model.Sentence;
 import cc.redpen.parser.LineOffset;
 import cc.redpen.validator.ValidationError;
 import org.json.JSONArray;
@@ -120,7 +121,8 @@ public class JSONFormatter extends Formatter {
      * @throws JSONException
      */
     protected JSONObject asJSON(LineOffset startLineOffset, LineOffset endLineOffset) throws JSONException {
-        return asJSON(startLineOffset.lineNum, startLineOffset.offset, endLineOffset.lineNum, endLineOffset.offset);
+        JSONObject json = asJSON(startLineOffset.lineNum, startLineOffset.offset, endLineOffset.lineNum, endLineOffset.offset);
+        return json;
     }
 
     /**
@@ -144,6 +146,24 @@ public class JSONFormatter extends Formatter {
         offset.put("offset", endOffset);
         position.put("end", offset);
         return position;
+    }
+
+    /**
+     * Render a start and end line offsets (ie: source text coordinates) as a description of a section of the sentence.getContent() string
+     *
+     * @param sentence        the sentence in which the offsets are located
+     * @param startLineOffset the line offset denoting the start position
+     * @param endLineOffset   the line offset denoting the end position
+     * @return a JSON representation of the offsets describing a section within the sentence's getContent() string
+     * @throws JSONException
+     */
+    protected JSONObject asJSON(Sentence sentence, LineOffset startLineOffset, LineOffset endLineOffset) throws JSONException {
+        JSONObject json = new JSONObject();
+        int start = sentence.getOffsetPosition(startLineOffset);
+        int length = Math.max(sentence.getOffsetPosition(endLineOffset) - start, 0);
+        json.put("offset", start);
+        json.put("length", length);
+        return json;
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -229,6 +229,17 @@ public final class Sentence implements Serializable {
     }
 
     /**
+     * Get the position of the supplied offset (ie: the position in the source text) in this sentence's normalized content
+     *
+     * @param offset the position in the source text
+     * @return the position in the setence's content
+     */
+    public int getOffsetPosition(LineOffset offset) {
+        int position = offsetMap.indexOf(offset);
+        return position < 0 ? 0 : position;
+    }
+
+    /**
      * Get size of offset mapping table (the size should be same as the content length).
      *
      * @return size of position mapping table

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -53,7 +53,7 @@ public final class Sentence implements Serializable {
     private boolean isFirstSentence;
     /**
      * A list of tokens.
-     *
+     * <p/>
      * Note: the contents of the tokens are added in DocumentCollectionBuilder
      */
     private List<TokenElement> tokens;
@@ -65,10 +65,10 @@ public final class Sentence implements Serializable {
     /**
      * Constructor.
      *
-     * @param sentenceContent  content of sentence
-     * @param lineNum line number of sentence
+     * @param sentenceContent content of sentence
+     * @param lineNum         line number of sentence
      */
-    public Sentence(String sentenceContent, int lineNum){
+    public Sentence(String sentenceContent, int lineNum) {
         this(sentenceContent, lineNum, 0);
     }
 
@@ -77,7 +77,7 @@ public final class Sentence implements Serializable {
      *
      * @param sentenceContent  content of sentence
      * @param sentencePosition sentence position
-     * @param startOffset offset of the start position in the line
+     * @param startOffset      offset of the start position in the line
      */
     public Sentence(String sentenceContent, int sentencePosition, int startOffset) {
         super();
@@ -97,7 +97,7 @@ public final class Sentence implements Serializable {
         this.startPositionOffset = offsetMap.get(0).offset;
         this.lineNumber = offsetMap.get(0).lineNum;
         this.isFirstSentence = false;
-        this.tokens =  new ArrayList<>();
+        this.tokens = new ArrayList<>();
         this.links = links;
     }
 
@@ -130,6 +130,7 @@ public final class Sentence implements Serializable {
 
     /**
      * Add a link to Sentence
+     *
      * @param link link url
      */
     public void addLink(String link) {
@@ -156,6 +157,7 @@ public final class Sentence implements Serializable {
 
     /**
      * Get start column offset where the sentence starts.
+     *
      * @return column offset of start sentence
      */
     public int getStartPositionOffset() {
@@ -174,6 +176,7 @@ public final class Sentence implements Serializable {
 
     /**
      * Set a flag to detect if the sentence is a first sentence of a paragraph.
+     *
      * @param isFirstSentence a flag to detect if the sentence exists in the begging of a paragraph
      */
     public void setIsFirstSentence(boolean isFirstSentence) {
@@ -182,6 +185,7 @@ public final class Sentence implements Serializable {
 
     /**
      * Get a set of tokenized words in the sentence.
+     *
      * @return list of tokenized words
      */
     public List<TokenElement> getTokens() {
@@ -190,6 +194,7 @@ public final class Sentence implements Serializable {
 
     /**
      * Set a set of tokenized words.
+     *
      * @param tokens tokenized words
      */
     public void setTokens(List<TokenElement> tokens) {
@@ -197,7 +202,6 @@ public final class Sentence implements Serializable {
     }
 
     /**
-<<<<<<< HEAD
      * Set the offset mapping table which contains character position to column offset in line.
      *
      * @param offsetMap position mapping table
@@ -217,10 +221,10 @@ public final class Sentence implements Serializable {
         if (this.offsetMap.size() > position) {
             return Optional.of(this.offsetMap.get(position));
         } else if (this.offsetMap.size() == position && offsetMap.size() > 0) {
-            LineOffset prev = this.offsetMap.get(position-1);
-            return Optional.of(new LineOffset(prev.lineNum, prev.offset+1));
+            LineOffset prev = this.offsetMap.get(position - 1);
+            return Optional.of(new LineOffset(prev.lineNum, prev.offset + 1));
         } else {
-            return Optional.empty();
+            return Optional.of(new LineOffset(lineNumber, position));
         }
     }
 

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -218,14 +218,16 @@ public final class Sentence implements Serializable {
      * @return offset position
      */
     public Optional<LineOffset> getOffset(int position) {
-        if (this.offsetMap.size() > position) {
-            return Optional.of(this.offsetMap.get(position));
-        } else if (this.offsetMap.size() == position && offsetMap.size() > 0) {
-            LineOffset prev = this.offsetMap.get(position - 1);
-            return Optional.of(new LineOffset(prev.lineNum, prev.offset + 1));
-        } else {
+        if (position >= 0) {
+            if (offsetMap.size() > position) {
+                return Optional.of(offsetMap.get(position));
+            } else if ((position > 0) && (offsetMap.size() == position)) {
+                LineOffset prev = offsetMap.get(position - 1);
+                return Optional.of(new LineOffset(prev.lineNum, prev.offset + 1));
+            }
             return Optional.of(new LineOffset(lineNumber, position));
         }
+        return Optional.empty();
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
@@ -36,8 +36,7 @@ import java.util.Optional;
  * Parser for plain text file.
  */
 final class PlainTextParser extends BaseDocumentParser implements Serializable {
-    private static final Logger LOG =
-            LoggerFactory.getLogger(PlainTextParser.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PlainTextParser.class);
     private static final long serialVersionUID = -4343255148183552844L;
 
     /**
@@ -60,19 +59,18 @@ final class PlainTextParser extends BaseDocumentParser implements Serializable {
         BufferedReader br = createReader(is);
         String remain = "";
         String line;
-        int lineNum = 1;
+        int lineNum = 0;
         try {
             while ((line = br.readLine()) != null) {
+                lineNum++;
                 int periodPosition = sentenceExtractor.getSentenceEndPosition(line);
                 if (line.equals("")) {
                     documentBuilder.addParagraph();
                 } else if (periodPosition == -1) {
                     remain = remain + line;
                 } else {
-                    remain =
-                            this.extractSentences(lineNum, remain + line, sentenceExtractor, documentBuilder);
+                    remain = this.extractSentences(lineNum, remain + line, sentenceExtractor, documentBuilder);
                 }
-                lineNum++;
             }
         } catch (IOException e) {
             throw new RedPenException(e);

--- a/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
@@ -56,45 +56,82 @@ final class PlainTextParser extends BaseDocumentParser implements Serializable {
         headers.add(new Sentence("", 0));
         documentBuilder.addSection(0, headers);
         documentBuilder.addParagraph();
+
         BufferedReader br = createReader(is);
-        String remain = "";
         String line;
-        int lineNum = 0;
+        int linesRead = 0;
+        int startLine = 1;
+        String paragraph = "";
         try {
             while ((line = br.readLine()) != null) {
-                lineNum++;
-                int periodPosition = sentenceExtractor.getSentenceEndPosition(line);
+                linesRead++;
                 if (line.equals("")) {
+                    if (!paragraph.isEmpty()) {
+                        this.extractSentences(startLine, paragraph, sentenceExtractor, documentBuilder);
+                        startLine = linesRead + 1;
+                    }
                     documentBuilder.addParagraph();
-                } else if (periodPosition == -1) {
-                    remain = remain + line;
+                    paragraph = "";
                 } else {
-                    remain = this.extractSentences(lineNum, remain + line, sentenceExtractor, documentBuilder);
+                    paragraph += (paragraph.isEmpty() ? "" : "\n") + line;
                 }
             }
         } catch (IOException e) {
             throw new RedPenException(e);
         }
-        if (remain.length() > 0) {
-            documentBuilder.addSentence(remain, lineNum);
+
+        if (!paragraph.isEmpty()) {
+            this.extractSentences(startLine, paragraph, sentenceExtractor, documentBuilder);
         }
         return documentBuilder.build();
     }
 
-    private String extractSentences(int lineNum, String line, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
-        int offset = 0;
-        int periodPosition = sentenceExtractor.getSentenceEndPosition(line);
+
+    /* Add a sentence with offsets */
+    private LineOffset addSentence(LineOffset lineOffset, String rawSentenceText, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
+
+        int lineNum = lineOffset.lineNum;
+        int offset = lineOffset.offset;
+        List<LineOffset> offsetMap = new ArrayList<>();
+        String normalizedSentence = "";
+        for (int i = 0; i < rawSentenceText.length(); i++) {
+            char ch = rawSentenceText.charAt(i);
+            if (ch == '\n') {
+                if (!sentenceExtractor.getBrokenLineSeparator().isEmpty()) {
+                    offsetMap.add(new LineOffset(lineNum, offset));
+                    normalizedSentence += sentenceExtractor.getBrokenLineSeparator();
+                }
+                lineNum++;
+                offset = 0;
+            } else {
+                normalizedSentence += ch;
+                offsetMap.add(new LineOffset(lineNum, offset));
+                offset++;
+            }
+        }
+        Sentence sentence = new Sentence(normalizedSentence, lineNum, lineOffset.offset);
+        sentence.setOffsetMap(offsetMap);
+        builder.addSentence(sentence);
+
+        return new LineOffset(lineNum, offset);
+    }
+
+    /* Extract sentences from a paragraph */
+    private void extractSentences(int lineNum, String paragraphText, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
+        int periodPosition = sentenceExtractor.getSentenceEndPosition(paragraphText);
+        LineOffset lineOffset = new LineOffset(lineNum, 0);
         if (periodPosition == -1) {
-            return line;
+            addSentence(lineOffset, paragraphText, sentenceExtractor, builder);
         } else {
             while (true) {
-                Sentence sentence = new Sentence(line.substring(0, periodPosition + 1), lineNum, offset);
-                builder.addSentence(sentence);
-                offset = periodPosition + 1;
-                line = line.substring(offset, line.length());
-                periodPosition = sentenceExtractor.getSentenceEndPosition(line);
+                lineOffset = addSentence(lineOffset, paragraphText.substring(0, periodPosition + 1), sentenceExtractor, builder);
+                paragraphText = paragraphText.substring(periodPosition + 1, paragraphText.length());
+                periodPosition = sentenceExtractor.getSentenceEndPosition(paragraphText);
                 if (periodPosition == -1) {
-                    return line;
+                    if (!paragraphText.isEmpty()) {
+                        addSentence(lineOffset, paragraphText, sentenceExtractor, builder);
+                    }
+                    return;
                 }
             }
         }

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -47,6 +47,8 @@ public final class SentenceExtractor {
             "May.", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.",
             "Nov.", "Dec.", "Feb.", "B.C", "A.D.");
     private EndOfSentenceDetector endOfSentenceDetector;
+    // reference to the symbol table used to create us
+    private SymbolTable symbolTable = null;
 
     /**
      * Constructor.
@@ -64,6 +66,7 @@ public final class SentenceExtractor {
      */
     public SentenceExtractor(SymbolTable symbolTable) {
         this(extractPeriods(symbolTable), extractRightQuotations(symbolTable));
+        this.symbolTable = symbolTable;
     }
 
     /**
@@ -144,9 +147,9 @@ public final class SentenceExtractor {
     public int extract(String line, List<Pair<Integer, Integer>> sentencePositions) {
         int startPosition = 0;
         int periodPosition = endOfSentenceDetector.getSentenceEndPosition(line);
-        while (periodPosition >= 0 ) {
-            sentencePositions.add(new Pair<>(startPosition, periodPosition+1));
-            startPosition = periodPosition+1;
+        while (periodPosition >= 0) {
+            sentencePositions.add(new Pair<>(startPosition, periodPosition + 1));
+            startPosition = periodPosition + 1;
             periodPosition = endOfSentenceDetector.getSentenceEndPosition(line, startPosition);
         }
         return startPosition;
@@ -160,6 +163,18 @@ public final class SentenceExtractor {
      */
     public int getSentenceEndPosition(String str) {
         return endOfSentenceDetector.getSentenceEndPosition(str);
+    }
+
+    /**
+     * Return the string that should be used to re-join lines broken with \n in
+     * <p/>
+     * For English, this is a space.
+     * For Japanese, it is an empty string.
+     *
+     * @return a string used to join lines that have been 'broken'
+     */
+    public String getBrokenLineSeparator() {
+        return (symbolTable != null) && (symbolTable.getLang().equals("ja")) ? "" : " ";
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/SentenceExtractor.java
@@ -171,6 +171,8 @@ public final class SentenceExtractor {
      * For English, this is a space.
      * For Japanese, it is an empty string.
      *
+     * The specification of this string should be moved to part of the configuration
+     *
      * @return a string used to join lines that have been 'broken'
      */
     public String getBrokenLineSeparator() {

--- a/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/markdown/ToFileContentSerializer.java
@@ -163,7 +163,7 @@ public class ToFileContentSerializer implements Visitor {
                     sentencePosition.second);
             outputSentences.add(new Sentence(line.substring(
                     sentencePosition.first, sentencePosition.second), offsetMap,
-                    mergedCandidateSentence.getRangedLinks(sentencePosition.first, sentencePosition.second-1)));
+                    mergedCandidateSentence.getRangedLinks(sentencePosition.first, sentencePosition.second - 1)));
         }
         if (lastPosition < mergedCandidateSentence.getContents().length()) {
             List<LineOffset> offsetMap = mergedCandidateSentence.getOffsetMap().subList(lastPosition,
@@ -334,8 +334,8 @@ public class ToFileContentSerializer implements Visitor {
         switch (simpleNode.getType()) {
             case Linebreak:
                 addCandidateSentence(
-                        getLineNumberFromStartIndex(simpleNode.getStartIndex()+1),
-                        " ", 0); //NOTE: column Offset of Linebreak should be always 0.
+                        getLineNumberFromStartIndex(simpleNode.getStartIndex() + 1),
+                        sentenceExtractor.getBrokenLineSeparator(), 0); //NOTE: column Offset of Linebreak should be always 0.
                 break;
             case Nbsp:
                 break;

--- a/redpen-core/src/main/java/cc/redpen/tokenizer/JapaneseTokenizer.java
+++ b/redpen-core/src/main/java/cc/redpen/tokenizer/JapaneseTokenizer.java
@@ -36,7 +36,7 @@ public class JapaneseTokenizer implements RedPenTokenizer {
     public List<TokenElement> tokenize(String content) {
         List<TokenElement> tokens = new ArrayList<>();
         for (Token token : tokenizer.tokenize(content)) {
-            tokens.add(new TokenElement(token.getSurfaceForm(), Arrays.asList(token.getAllFeaturesArray())));
+            tokens.add(new TokenElement(token.getSurfaceForm(), Arrays.asList(token.getAllFeaturesArray()), token.getPosition()));
         }
         return tokens;
     }

--- a/redpen-core/src/main/java/cc/redpen/tokenizer/TokenElement.java
+++ b/redpen-core/src/main/java/cc/redpen/tokenizer/TokenElement.java
@@ -25,23 +25,32 @@ import java.util.List;
 
 public final class TokenElement implements Serializable {
     private static final long serialVersionUID = -7779529873101010570L;
+
+    // the surface form of the token
     final private String surface;
 
+    // token metadata (POS, etc)
     final private List<String> tags;
 
+    // the character position of the token in the sentence
+    final private int offset;
+
     TokenElement(String word) {
-        surface = word;
-        tags = Collections.unmodifiableList(new ArrayList<>());
+        this(word, Collections.unmodifiableList(new ArrayList<>()), 0);
     }
 
     TokenElement(String word, String tag) {
-        surface = word;
-        tags = Collections.unmodifiableList(Arrays.asList(tag));
+        this(word, Collections.unmodifiableList(Arrays.asList(tag)), 0);
     }
 
     TokenElement(String word, List<String> tagList) {
+        this(word, Collections.unmodifiableList(tagList), 0);
+    }
+
+    TokenElement(String word, List<String> tagList, int offset) {
         surface = word;
         tags = Collections.unmodifiableList(tagList);
+        this.offset = offset;
     }
 
     public String getSurface() {
@@ -50,6 +59,10 @@ public final class TokenElement implements Serializable {
 
     public List<String> getTags() {
         return tags;
+    }
+
+    public int getOffset() {
+        return offset;
     }
 
     @Override
@@ -76,6 +89,7 @@ public final class TokenElement implements Serializable {
     public String toString() {
         return "TokenElement{" +
                 "surface='" + surface + '\'' +
+                ", offset=" + offset +
                 ", tags=" + tags +
                 '}';
     }

--- a/redpen-core/src/main/java/cc/redpen/tokenizer/WhiteSpaceTokenizer.java
+++ b/redpen-core/src/main/java/cc/redpen/tokenizer/WhiteSpaceTokenizer.java
@@ -23,10 +23,11 @@ import java.util.regex.Pattern;
 
 public class WhiteSpaceTokenizer implements RedPenTokenizer {
 
-    private static Pattern[] BLACKLIST_TOKEN_PATTERNS = new Pattern[]{
+    private static final Pattern[] BLACKLIST_TOKEN_PATTERNS = new Pattern[]{
             Pattern.compile("^[-+]?\\d+(\\.\\d+)?$") // a number [+-]n[.n]
     };
 
+    private static final String DELIMITERS = " \t\n\r?!,:;.()\u2014\"";
 
     public WhiteSpaceTokenizer() {
     }
@@ -36,42 +37,27 @@ public class WhiteSpaceTokenizer implements RedPenTokenizer {
         List<TokenElement> tokens = new ArrayList<>();
 
         String surface = "";
-        int tokenStart = 0;
+        int offset = 0;
         List<String> tags = new ArrayList<>();
 
         for (int i = 0, l = content.length(); i < l; i++) {
-            char c = content.charAt(i);
-            switch (c) {
-                case ' ':
-                case '?':
-                case ',':
-                case ':':
-                case ';':
-                case '.':
-                case '(':
-                case ')':
-                case '\u2014': // mdash
-                case '"':
-                case '\t':
-                case '\r':
-                case '\n':
-                    if (isSuitableToken(surface)) {
-                        tokens.add(new TokenElement(surface, tags, tokenStart));
-                    }
-                    surface = "";
-                    tokenStart = -1;
-                    break;
-                default:
-                    if (tokenStart < 0) {
-                        tokenStart = i;
-                    }
-                    surface += c;
-                    break;
+            char ch = content.charAt(i);
+            if (DELIMITERS.indexOf(ch) != -1) {
+                if (isSuitableToken(surface)) {
+                    tokens.add(new TokenElement(surface, tags, offset));
+                }
+                surface = "";
+                offset = -1;
+            } else {
+                if (offset < 0) {
+                    offset = i;
+                }
+                surface += ch;
             }
         }
 
         if (isSuitableToken(surface)) {
-            tokens.add(new TokenElement(surface, tags, tokenStart));
+            tokens.add(new TokenElement(surface, tags, offset));
         }
 
         return tokens;

--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -25,6 +25,7 @@ import cc.redpen.model.Document;
 import cc.redpen.model.Section;
 import cc.redpen.model.Sentence;
 import cc.redpen.parser.LineOffset;
+import cc.redpen.tokenizer.TokenElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,6 +198,22 @@ public abstract class Validator {
      */
     protected ValidationError createValidationError(String messageKey, Sentence sentenceWithError, Object... args) {
         return new ValidationError(this.getClass(), getLocalizedErrorMessage(Optional.of(messageKey), args), sentenceWithError);
+    }
+
+    /**
+     * create a ValidationError using the details within the given token
+     *
+     * @param sentenceWithError sentence
+     * @param token             the TokenElement that has the error
+     * @return ValidationError with localized message
+     */
+    protected ValidationError createValidationErrorFromToken(Sentence sentenceWithError, TokenElement token) {
+        return createValidationErrorWithPosition(
+                sentenceWithError,
+                sentenceWithError.getOffset(token.getOffset()),
+                sentenceWithError.getOffset(token.getOffset() + token.getSurface().length()),
+                token.getSurface()
+        );
     }
 
     /**

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/ContractionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/ContractionValidator.java
@@ -133,7 +133,7 @@ final public class ContractionValidator extends Validator {
             String surface = token.getSurface().toLowerCase();
             if (foundNonContractionNum >= foundContractionNum
                     && contractions.contains(surface)) {
-                errors.add(createValidationError(sentence, surface));
+                errors.add(createValidationErrorFromToken(sentence, token));
             }
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/DoubledWordValidator.java
@@ -47,7 +47,7 @@ final public class DoubledWordValidator extends Validator {
         for (TokenElement token : sentence.getTokens()) {
             String currentSurface = token.getSurface();
             if (surfaces.contains(currentSurface) && !skipList.contains(currentSurface.toLowerCase())) {
-                errors.add(createValidationError(sentence, currentSurface));
+                errors.add(createValidationErrorFromToken(sentence, token));
             }
             surfaces.add(currentSurface);
         }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/InvalidWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/InvalidWordValidator.java
@@ -50,7 +50,7 @@ final public class InvalidWordValidator extends Validator {
         //NOTE: only Ascii white space since this validator works for european languages.
         for (TokenElement token : sentence.getTokens()) {
             if (invalidWords.contains(token.getSurface().toLowerCase())) {
-                errors.add(createValidationError(sentence, token.getSurface()));
+                errors.add(createValidationErrorFromToken(sentence, token));
             }
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/KatakanaEndHyphenValidator.java
@@ -35,16 +35,16 @@ import java.util.Locale;
  * "コンピュータ (without hyphen) ", and "コンピューター (with hypen) ".
  * This validator validate if Katakana words ending format is match
  * the predefined standard. See JIS Z8301, G.6.2.2 b) G.3.
- * <p>
+ * <p/>
  * The rules in JIS Z8301 are as follows:
- * <p>
+ * <p/>
  * a) Words of 3 characters or more can not have the end hyphen.
  * b) Words of 2 characters or less can have the end hyphen.
  * c) A compound word applies a) and b) for each component.
  * d) In the cases from a) to c), the length of a syllable
  * which are represented as a hyphen, flip syllable,
  * and stuffed syllable is 1 except for Youon.
- * <p>
+ * <p/>
  * Note that KatakanaEndHyphenValidator only checks the rules a) and b).
  */
 final public class KatakanaEndHyphenValidator extends Validator {
@@ -84,24 +84,25 @@ final public class KatakanaEndHyphenValidator extends Validator {
             if (StringUtils.isKatakana(c) && c != KATAKANA_MIDDLE_DOT) {
                 katakana.append(c);
             } else {
-                result = this.checkKatakanaEndHyphen(sentence, katakana);
+                result = this.checkKatakanaEndHyphen(sentence, katakana, i-1);
                 if (result != null) {
                     errors.addAll(result);
                 }
                 katakana.delete(0, katakana.length());
             }
         }
-        result = this.checkKatakanaEndHyphen(sentence, katakana);
+        result = this.checkKatakanaEndHyphen(sentence, katakana, sentence.getContent().length() - 1);
         if (result != null) {
             errors.addAll(result);
         }
     }
 
     private List<ValidationError> checkKatakanaEndHyphen(Sentence sentence,
-                                                         StringBuilder katakana) {
+                                                         StringBuilder katakana,
+                                                         int position) {
         List<ValidationError> errors = new ArrayList<>();
         if (isKatakanaEndHyphen(katakana)) {
-            errors.add(createValidationError(sentence, katakana.toString()));
+            errors.add(createValidationErrorWithPosition(sentence, sentence.getOffset(position), sentence.getOffset(position + 1), katakana.toString()));
         }
         return errors;
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpaceBeginningOfSentenceValidator.java
@@ -33,14 +33,14 @@ import java.util.Map;
 final public class SpaceBeginningOfSentenceValidator extends Validator {
     private Map<Integer, List<Sentence>> sentencePositions = new HashMap<>();
 
-    private boolean isFistInLine(Sentence sentence) {
+    private boolean isFirstInLine(Sentence sentence) {
         return sentence.isFirstSentence() || sentencePositions.get(sentence.getLineNumber()).get(0) == sentence;
     }
 
     @Override
     public void validate(List<ValidationError> errors, Sentence sentence) {
         String content = sentence.getContent();
-        if (!isFistInLine(sentence) && content.length() > 0 && content.charAt(0) != ' ') {
+        if (!isFirstInLine(sentence) && content.length() > 0 && content.charAt(0) != ' ') {
             errors.add(createValidationErrorWithPosition(sentence,
                     sentence.getOffset(0),
                     sentence.getOffset(1)));

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
@@ -88,7 +88,7 @@ public class SpellingValidator extends Validator {
             }
 
             if (!this.validWords.contains(surface)) {
-                errors.add(createValidationError(sentence, surface));
+                errors.add(createValidationErrorFromToken(sentence, token));
             }
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SuccessiveWordValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SuccessiveWordValidator.java
@@ -32,7 +32,7 @@ public class SuccessiveWordValidator extends Validator {
         for (TokenElement token : sentence.getTokens()) {
             String currentSurface = token.getSurface();
             if (prevSurface.equals(currentSurface) && currentSurface.length() > 0) {
-                errors.add(createValidationError(sentence, currentSurface));
+                errors.add(createValidationErrorFromToken(sentence, token));
             }
             prevSurface = currentSurface;
         }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SymbolWithSpaceValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SymbolWithSpaceValidator.java
@@ -64,8 +64,8 @@ public class SymbolWithSpaceValidator extends Validator {
                     && symbol.isNeedAfterSpace()
                     && !Character.isWhitespace(sentenceStr.charAt(position + 1))) {
                 return createValidationErrorWithPosition(sentence,
+                        sentence.getOffset(position),
                         sentence.getOffset(position+1),
-                        sentence.getOffset(position+2),
                         sentenceStr.charAt(position));
             }
         }

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import static cc.redpen.config.SymbolType.COMMA;
 import static cc.redpen.config.SymbolType.FULL_STOP;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class MarkdownParserTest {
 
@@ -58,7 +59,7 @@ public class MarkdownParserTest {
     public void testBasicDocument() throws UnsupportedEncodingException {
         String sampleText = "";
         sampleText += "# About Gekioko.\n";
-        sampleText += "Gekioko pun pun maru means very very angry.\n";
+        sampleText += "Gekioko pun pun maru means _very very_ angry.\n";
         sampleText += "\n";
         sampleText += "The word also has a positive meaning.\n";
         sampleText += "## About Gunma.\n";
@@ -71,9 +72,10 @@ public class MarkdownParserTest {
         sampleText += "* Location\n";
         sampleText += "    * Japan\n";
         sampleText += "\n";
-        sampleText += "The word also have positive meaning. However it is a bit wired.";
+        sampleText += "The word also have positive meaning. However it is a bit weird.";
 
         Document doc = createFileContent(sampleText);
+
         assertNotNull("doc is null", doc);
         assertEquals(3, doc.size());
         // first section
@@ -129,11 +131,12 @@ public class MarkdownParserTest {
         assertEquals(36, lastSection.getParagraph(1).getSentence(1).getStartPositionOffset());
     }
 
+
     @Test
     public void testGenerateDocumentWithHeaderedDocument() {
         String sampleText = "# Validator\n"
-        + "Validator class is a abstract class in RedPen project.\n"
-        + "Functions provided by RedPen class are implemented with validator class.\n";
+                + "Validator class is a abstract class in RedPen project.\n"
+                + "Functions provided by RedPen class are implemented with validator class.\n";
         Document doc = createFileContent(sampleText);
 
         final Section secondSection = doc.getSection(1);
@@ -164,7 +167,7 @@ public class MarkdownParserTest {
                 new LineOffset(3, 0), // F NOTE: even when there is a Linebreak, sentence start from offset "0".
                 new LineOffset(3, 1)  // u
         );
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i), secondSection.getParagraph(0).getSentence(1).getOffset(i).get());
         }
 
@@ -320,7 +323,7 @@ public class MarkdownParserTest {
 
     }
 
-        @Test
+    @Test
     public void testGenerateDocumentWitVoidContent() {
         String sampleText = "";
         Document doc = createFileContent(sampleText);
@@ -395,7 +398,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 37));
 
         assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).getOffset(i).get());
         }
     }
@@ -489,7 +492,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 16));
 
         assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).getOffset(i).get());
         }
     }
@@ -521,7 +524,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 18));
 
         assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).getOffset(i).get());
         }
     }
@@ -553,7 +556,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 20));
 
         assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).getOffset(i).get());
         }
     }
@@ -584,7 +587,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 23),
                 new LineOffset(1, 24));
         assertEquals(expectedOffsets.size(), firstParagraph.getSentence(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i), firstParagraph.getSentence(0).getOffset(i).get());
         }
     }
@@ -595,7 +598,7 @@ public class MarkdownParserTest {
         String sampleText = "";
         sampleText += "# About Gunma. About Saitama.\n";
         sampleText += "Gunma is located at west of Saitama.\n";
-        sampleText += "The word also have positive meaning. However it is a bit wired.";
+        sampleText += "The word also have positive meaning. However it is a bit weird.";
 
         Document doc = createFileContent(sampleText);
         Section lastSection = doc.getSection(doc.size() - 1);
@@ -620,7 +623,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 13));
 
         assertEquals(expectedOffsets1.size(), lastSection.getHeaderContent(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets1.size() ; i++) {
+        for (int i = 0; i < expectedOffsets1.size(); i++) {
             assertEquals(expectedOffsets1.get(i),
                     lastSection.getHeaderContent(0).getOffset(i).get());
         }
@@ -647,7 +650,7 @@ public class MarkdownParserTest {
         assertEquals(14, lastSection.getHeaderContent(1).getStartPositionOffset());
 
         assertEquals(expectedOffsets2.size(), lastSection.getHeaderContent(1).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets2.size() ; i++) {
+        for (int i = 0; i < expectedOffsets2.size(); i++) {
             assertEquals(expectedOffsets2.get(i),
                     lastSection.getHeaderContent(1).getOffset(i).get());
         }
@@ -680,7 +683,7 @@ public class MarkdownParserTest {
                 new LineOffset(1, 11),
                 new LineOffset(1, 12));
         assertEquals(expectedOffsets.size(), lastSection.getHeaderContent(0).getOffsetMapSize());
-        for (int i = 0; i < expectedOffsets.size() ; i++) {
+        for (int i = 0; i < expectedOffsets.size(); i++) {
             assertEquals(expectedOffsets.get(i),
                     lastSection.getHeaderContent(0).getOffset(i).get());
         }
@@ -796,12 +799,45 @@ public class MarkdownParserTest {
         String sampleText = "";
         sampleText += "# Table\n\n" +
                 "|--------|-------|\n" +
-                "|Cool    | Shit  |\n" +
+                "|Cool    | Stuff  |\n" +
                 "|is this | really\n";
 
         Document doc = createFileContent(sampleText);
         Section lastSection = doc.getSection(doc.size() - 1);
         assertEquals(0, lastSection.getNumberOfParagraphs());
+    }
+
+    @Test
+    public void testJapaneseDocumentSentences() throws UnsupportedEncodingException {
+        String sampleText = "";
+        sampleText += "# 僕の事。\n";
+        sampleText += "わたしはカラオケが大好きです。\n";
+        sampleText += "わたしもお寿司が大好きです。\n";
+        sampleText += "\n";
+
+        Document doc = createFileContent(sampleText, new Configuration.ConfigurationBuilder().setLanguage("ja").build());
+
+        assertNotNull("doc is null", doc);
+        assertEquals(2, doc.size());
+        // first section
+        final Section firstSection = doc.getSection(0);
+        assertEquals(1, firstSection.getHeaderContentsListSize());
+        assertEquals("", firstSection.getHeaderContent(0).getContent());
+        assertEquals(0, firstSection.getNumberOfLists());
+        assertEquals(0, firstSection.getNumberOfParagraphs());
+        assertEquals(1, firstSection.getNumberOfSubsections());
+
+        // 2nd section
+        final Section secondSection = doc.getSection(1);
+        assertEquals(1, secondSection.getHeaderContentsListSize());
+        assertEquals("僕の事。", secondSection.getHeaderContent(0).getContent());
+        assertEquals(1, secondSection.getHeaderContent(0).getLineNumber());
+        assertEquals(2, secondSection.getHeaderContent(0).getStartPositionOffset());
+        assertEquals(0, secondSection.getNumberOfLists());
+        assertEquals(1, secondSection.getNumberOfParagraphs());
+        assertEquals(2, secondSection.getParagraph(0).getNumberOfSentences());
+        assertEquals("わたしもお寿司が大好きです。", secondSection.getParagraph(0).getSentence(1).getContent());
+        assertEquals(firstSection, secondSection.getParentSection());
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
@@ -23,6 +23,7 @@ import cc.redpen.model.Document;
 import cc.redpen.model.Paragraph;
 import cc.redpen.model.Section;
 import cc.redpen.parser.DocumentParser;
+import cc.redpen.parser.LineOffset;
 import cc.redpen.parser.SentenceExtractor;
 import cc.redpen.validator.ValidationError;
 import org.junit.Before;
@@ -73,7 +74,7 @@ public class PlainTextParserTest {
                 .addValidatorConfig(
                         new ValidatorConfiguration("SentenceLength").addAttribute("max_length", "10"))
                 .build();
-            parser = DocumentParser.PLAIN;
+        parser = DocumentParser.PLAIN;
     }
 
     @Test
@@ -199,7 +200,7 @@ public class PlainTextParserTest {
         assertEquals("InvalidSymbol", errors.get(0).getValidatorName());
         assertEquals(19, errors.get(0).getSentence().getContent().length());
         // plain text parser does not support error position.
-        assertEquals(Optional.empty(), errors.get(0).getStartPosition());
-        assertEquals(Optional.empty(), errors.get(0).getEndPosition());
+        assertEquals(Optional.of(new LineOffset(1, 18)), errors.get(0).getStartPosition());
+        assertEquals(Optional.of(new LineOffset(1, 19)), errors.get(0).getEndPosition());
     }
 }

--- a/redpen-core/src/test/java/cc/redpen/WikiParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/WikiParserTest.java
@@ -24,6 +24,7 @@ import cc.redpen.model.ListBlock;
 import cc.redpen.model.Paragraph;
 import cc.redpen.model.Section;
 import cc.redpen.parser.DocumentParser;
+import cc.redpen.parser.LineOffset;
 import cc.redpen.parser.SentenceExtractor;
 import cc.redpen.validator.ValidationError;
 import org.junit.Before;
@@ -618,13 +619,11 @@ public class WikiParserTest {
         assertEquals(1, errors.size());
         assertEquals("InvalidSymbol", errors.get(0).getValidatorName());
         assertEquals(19, errors.get(0).getSentence().getContent().length());
-        // wiki parser does not support error position.
-        assertEquals(Optional.empty(), errors.get(0).getStartPosition());
-        assertEquals(Optional.empty(), errors.get(0).getEndPosition());
+        assertEquals(Optional.of(new LineOffset(1, 18)), errors.get(0).getStartPosition());
+        assertEquals(Optional.of(new LineOffset(1, 19)), errors.get(0).getEndPosition());
     }
 
-    private Document createFileContent(String inputDocumentString,
-                                       Configuration conf) {
+    private Document createFileContent(String inputDocumentString, Configuration conf) {
         DocumentParser parser = DocumentParser.WIKI;
         try {
             return parser.parse(inputDocumentString, new SentenceExtractor(conf.getSymbolTable()), conf.getTokenizer());
@@ -634,8 +633,7 @@ public class WikiParserTest {
         }
     }
 
-    private Document createFileContent(
-            String inputDocumentString) {
+    private Document createFileContent(String inputDocumentString) {
         Configuration conf = new Configuration.ConfigurationBuilder().build();
         DocumentParser parser = DocumentParser.WIKI;
         Document doc = null;

--- a/redpen-core/src/test/java/cc/redpen/formatter/JSONBySentenceFormatterTest.java
+++ b/redpen-core/src/test/java/cc/redpen/formatter/JSONBySentenceFormatterTest.java
@@ -41,7 +41,7 @@ public class JSONBySentenceFormatterTest extends Validator {
         assertEquals("testing JSONFormatter", sentenceErrors.getString("sentence"));
         assertEquals(0, sentenceErrors.getJSONObject("position").getJSONObject("start").getInt("offset"));
         assertEquals(1, sentenceErrors.getJSONObject("position").getJSONObject("start").getInt("line"));
-        assertEquals(21, sentenceErrors.getJSONObject("position").getJSONObject("end").getInt("offset"));
+        assertEquals(20, sentenceErrors.getJSONObject("position").getJSONObject("end").getInt("offset"));
         assertEquals(1, sentenceErrors.getJSONObject("position").getJSONObject("end").getInt("line"));
         assertNotNull(sentenceErrors.getJSONArray("errors"));
         assertEquals(1, sentenceErrors.getJSONArray("errors").length());

--- a/redpen-core/src/test/java/cc/redpen/parser/SentenceExtractorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/SentenceExtractorTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 public class SentenceExtractorTest {
 
     private List<Sentence> createSentences(List<Pair<Integer, Integer>> outputPositions,
-            int lastPosition, String line) {
+                                           int lastPosition, String line) {
         List<Sentence> output = new ArrayList<>();
         for (Pair<Integer, Integer> outputPosition : outputPositions) {
             output.add(new Sentence(line.substring(outputPosition.first, outputPosition.second), 0));
@@ -200,7 +200,7 @@ public class SentenceExtractorTest {
 
     @Test
     public void testJapaneseSimple() {
-        char[] stopChars = {'。','？'};
+        char[] stopChars = {'。', '？'};
         SentenceExtractor extractor = new SentenceExtractor(stopChars);
         final String input = "これは埼玉ですか？いいえ群馬です。";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
@@ -214,7 +214,7 @@ public class SentenceExtractorTest {
 
     @Test
     public void testJapaneseSimpleWithSpace() {
-        char[] stopChars = {'。','？'};
+        char[] stopChars = {'。', '？'};
         SentenceExtractor extractor = new SentenceExtractor(stopChars);
         final String input = "これは埼玉ですか？ いいえ群馬です。";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
@@ -228,8 +228,8 @@ public class SentenceExtractorTest {
 
     @Test
     public void testJapaneseSimpleWithEndQuotations() {
-        char[] stopChars = {'。','？'};
-        char[] rightQuotations = {'’','”'};
+        char[] stopChars = {'。', '？'};
+        char[] rightQuotations = {'’', '”'};
         SentenceExtractor extractor = new SentenceExtractor(stopChars, rightQuotations);
         final String input = "これは“群馬。”";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
@@ -242,8 +242,8 @@ public class SentenceExtractorTest {
 
     @Test
     public void testJapaneseMultipleSentencesWithEndQuotations() {
-        char[] stopChars = {'。','？'};
-        char[] rightQuotations = {'’','”'};
+        char[] stopChars = {'。', '？'};
+        char[] rightQuotations = {'’', '”'};
         SentenceExtractor extractor = new SentenceExtractor(stopChars, rightQuotations);
         final String input = "これは“群馬。”あれは群馬ではない。";
         List<Pair<Integer, Integer>> outputPositions = new ArrayList<>();
@@ -257,7 +257,7 @@ public class SentenceExtractorTest {
 
     @Test
     public void testJapaneseMultipleSentencesWithPartialSplit() {
-        char[] stopChars = {'．','？'};
+        char[] stopChars = {'．', '？'};
         char[] rightQuotations = {};
         SentenceExtractor extractor = new SentenceExtractor(stopChars, rightQuotations);
         final String input = "それは異なる．たとえば，\n" +
@@ -336,7 +336,7 @@ public class SentenceExtractorTest {
         assertEquals(input.length(), lastPosition);
     }
 
-//    @Test
+    //    @Test
 //    public void testConstructPatternString() {
 //        List<Character> endCharacters = new ArrayList<>();
 //        endCharacters.add('\\.');
@@ -348,7 +348,7 @@ public class SentenceExtractorTest {
 //
     @Test
     public void testConstructPatternStringWithoutEscape() {
-        char[] endCharacters = {'.','?','!'};
+        char[] endCharacters = {'.', '?', '!'};
         SentenceExtractor extractor = new SentenceExtractor(endCharacters);
         assertEquals("\\.'|\\?'|\\!'|\\.\"|\\?\"|\\!\"|\\.|\\?|\\!", extractor.constructEndSentencePattern().pattern());
     }

--- a/redpen-core/src/test/java/cc/redpen/parser/markdown/MergedCandidateSentenceTest.java
+++ b/redpen-core/src/test/java/cc/redpen/parser/markdown/MergedCandidateSentenceTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -65,6 +64,7 @@ public class MergedCandidateSentenceTest {
         }
 
     }
+
 
     private static List<CandidateSentence> initializeCandidateSentences(CandidateSentence... candidateSentences) {
         List<CandidateSentence> candidateSentenceList = new ArrayList<>();

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
@@ -23,6 +23,7 @@ import cc.redpen.config.Configuration;
 import cc.redpen.config.Symbol;
 import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.Document;
+import cc.redpen.parser.LineOffset;
 import cc.redpen.tokenizer.JapaneseTokenizer;
 import cc.redpen.validator.ValidationError;
 import junit.framework.Assert;
@@ -35,6 +36,7 @@ import java.util.Optional;
 
 import static cc.redpen.config.SymbolType.COMMA;
 import static cc.redpen.config.SymbolType.EXCLAMATION_MARK;
+import static org.junit.Assert.assertEquals;
 
 public class InvalidSymbolValidatorTest {
     @Test
@@ -56,9 +58,8 @@ public class InvalidSymbolValidatorTest {
         RedPen redPen = new RedPen(conf);
         Map<Document, List<ValidationError>> errors = redPen.validate(documents);
         Assert.assertEquals(1, errors.get(documents.get(0)).size());
-        // NOTE: no position without parsing
-        Assert.assertEquals(Optional.empty(), errors.get(documents.get(0)).get(0).getStartPosition());
-        Assert.assertEquals(Optional.empty(), errors.get(documents.get(0)).get(0).getEndPosition());
+        assertEquals(Optional.of(new LineOffset(1, 12)), errors.get(documents.get(0)).get(0).getStartPosition());
+        assertEquals(Optional.of(new LineOffset(1, 13)), errors.get(documents.get(0)).get(0).getEndPosition());
     }
 
     @Test

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
@@ -184,7 +184,7 @@ public class SymbolWithSpaceValidatorTest {
         List<ValidationError> errors = redPen.validate(documents).get(documents.get(0));
         assertEquals(1, errors.size());
         assertEquals("SymbolWithSpace", errors.get(0).getValidatorName());
-        assertEquals(new LineOffset(1, 18), errors.get(0).getStartPosition().get());
-        assertEquals(new LineOffset(1, 19), errors.get(0).getEndPosition().get());
+        assertEquals(new LineOffset(1, 17), errors.get(0).getStartPosition().get());
+        assertEquals(new LineOffset(1, 18), errors.get(0).getEndPosition().get());
     }
 }

--- a/redpen-server/src/main/webapp/css/redpen.css
+++ b/redpen-server/src/main/webapp/css/redpen.css
@@ -193,11 +193,7 @@ textarea {
     background-position: left 5px;
     background-repeat: no-repeat;
     padding-left: 18px;
-}
-
-.redpen-error-message {
-    color: rgb(205, 31, 0);
-    cursor: help;
+    margin-bottom: 24px;
 }
 
 .redpen-info-message {
@@ -218,9 +214,7 @@ textarea {
     padding: 1px;
     margin-left: 2px;
     font-size: 9px;
-    background-color: #aaa;
-    color: white;
-    border-radius: 4px;
+    color: #aaa;
     vertical-align: middle;
 }
 
@@ -274,5 +268,57 @@ textarea {
 
 .redpen-validators .checkbox i {
     color: #1C6100;
+}
+
+.redpen-error-list {
+    margin-left: 0;
+    padding-right: 0;
+    list-style-type: none;
+    padding-left: 18px;
+    margin-bottom: 20px;
+}
+
+.redpen-error-message {
+    color: rgb(124, 47, 0);
+    cursor: help;
+}
+
+.redpen-error-message-annotated::before  {
+    background-color: #FF713D !important;
+}
+
+.redpen-error-list li {
+    counter-increment: step-counter;
+}
+
+.redpen-error-list li::before {
+    content: counter(step-counter);
+    margin-right: 5px;
+    font-size: 80%;
+    background-color: grey;
+    color: white;
+    padding: 2px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-radius: 3px;
+}
+
+.redpen-annotated-sentence i {
+    color: #8d3700;
+    font-style: normal;
+}
+
+.redpen-annotated-sentence b {
+    font-weight: normal;
+    background-color: #FF713D;
+    color: #fff;
+    border-radius: 3px;
+    font-size: 60%;
+    display: inline-block;
+    line-height: 60%;
+    padding: 3px;
+    vertical-align: top;
+    text-align: center;
+    margin-right: 1px;
 }
 

--- a/redpen-server/src/main/webapp/css/redpen.css
+++ b/redpen-server/src/main/webapp/css/redpen.css
@@ -119,6 +119,20 @@ textarea {
     padding-right: 4px;
 }
 
+#redpen-results-report {
+    background-color: #111;
+    color: #06F400;
+    min-height: 100%;
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+    font-family: monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
 #redpen-settings {
     height: 100%;
     overflow-y: auto;
@@ -283,7 +297,7 @@ textarea {
     cursor: help;
 }
 
-.redpen-error-message-annotated::before  {
+.redpen-error-message-annotated::before {
     background-color: #FF713D !important;
 }
 
@@ -297,9 +311,10 @@ textarea {
     font-size: 80%;
     background-color: grey;
     color: white;
-    padding: 2px;
-    padding-left: 5px;
-    padding-right: 5px;
+    padding: 0;
+    display: inline-block;
+    text-align: center;
+    min-width: 20px;
     border-radius: 3px;
 }
 
@@ -309,6 +324,7 @@ textarea {
 }
 
 .redpen-annotated-sentence b {
+    cursor: help;
     font-weight: normal;
     background-color: #FF713D;
     color: #fff;

--- a/redpen-server/src/main/webapp/index.html
+++ b/redpen-server/src/main/webapp/index.html
@@ -172,6 +172,11 @@ $(document).ready(function () {
             showConfigurationOptions(firstValidRedpen);
         };
 
+        var getSourceLines = function () {
+            var document = $(editor).val();
+            return ("\n" + document).split("\n");
+        };
+
         // highlight a line in the editor
         var highlightEditor = function (error) {
             if (error) {
@@ -247,10 +252,10 @@ $(document).ready(function () {
                                     );
 
                             var addError = function (errorList, error) {
-
                                 if (validators[error.validator]) {
                                     $(errorList).append($('<li></li>')
                                             .addClass('redpen-error-message')
+                                            .toggleClass('redpen-error-message-annotated', error.annotated)
                                             .append(error.message)
                                             .mouseenter(function () {
                                                 highlightEditor(error);
@@ -265,20 +270,94 @@ $(document).ready(function () {
                                     )
                                 }
                             };
-                            for (var i = 0; i < errors.length; i++) {
-                                var errorDiv = $('<div></div>').addClass('redpen-error-section');
-                                var errorList = $('<ul></ul>');
-                                results.append(errorDiv);
-                                $(errorDiv)
-                                        .append($('<p></p>')
-                                                .addClass('redpen-error-sentence')
-                                                .html(errors[i].sentence)
-                                        )
-                                        .append(errorList);
 
-                                for (var j = 0; j < errors[i].errors.length; j++) {
-                                    addError(errorList, errors[i].errors[j]);
+                            var annotateDocument = function (errors) {
+                                var lines = getSourceLines();
+                                var annotated = [];
+                                for (var i = 1; i < lines.length; i++) {
+                                    var sentence = lines[i];
+                                    annotated[i] = [];
+                                    for (var j = 0; j < sentence.length; j++) {
+                                        annotated[i].push({char: sentence[j], errorStart: [], errorEnd: []});
+                                    }
                                 }
+                                for (var i = 0; i < errors.length; i++) {
+                                    var lineNo = errors[i].position.end.line;
+                                    if (lineNo < lines.length) {
+                                        var sentence = lines[lineNo];
+                                        var start = errors[i].position.start.offset ? errors[i].position.start.offset : 0;
+                                        var end = errors[i].position.end.offset ? errors[i].position.end.offset : 0;
+                                        if ((start != 0) || (end != 0)) {
+                                            if (annotated[lineNo][start]) {
+                                                annotated[lineNo][start].errorStart.push({id: i + 1, error: errors[i]});
+                                            }
+                                            errors[i].annotated = true;
+                                        }
+                                        if (annotated[lineNo][end]) {
+                                            annotated[lineNo][end].errorEnd.push({id: i + 1, error: errors[i]});
+                                            errors[i].annotated = true;
+                                        }
+
+                                    }
+                                }
+
+                                // renderer the errors as HTML
+                                var html = "";
+                                var errorOpen = false;
+                                for (var line = 1; line < annotated.length; line++) {
+                                    if (line != 1) {
+                                        html += "<br/>";
+                                    }
+                                    for (var i = 0; i < annotated[line].length; i++) {
+                                        if (errorOpen && annotated[line][i].errorEnd.length) {
+                                            html += "</i>";
+                                            errorOpen = false;
+                                        }
+                                        for (var j = 0; j < annotated[line][i].errorEnd.length; j++) {
+                                            html += "<b>" + annotated[line][i].errorEnd[j].id + "</b>";
+                                        }
+                                        if (annotated[line][i].errorStart.length) {
+                                            html += "<i>";
+                                            errorOpen = true;
+                                        }
+                                        if (errorOpen && annotated[line][i].errorEnd.length) {
+                                            html += "</i>";
+                                            errorOpen = false;
+                                        }
+                                        html += annotated[line][i].char;
+                                    }
+                                }
+
+                                return $("<span></span>").addClass("redpen-annotated-sentence").html(html);
+                            };
+
+                            var allErrors = [];
+                            for (var i = 0; i < errors.length; i++) {
+                                for (var j = 0; j < errors[i].errors.length; j++) {
+                                    // TODO: Consider putting absolute positions in the errors rather than sentence relative ones?
+                                    errors[i].errors[j].position.start.offset += errors[i].position.start.offset;
+                                    errors[i].errors[j].position.end.offset += errors[i].position.start.offset;
+                                    allErrors.push(errors[i].errors[j]);
+                                }
+                            }
+                            allErrors.sort(function (a, b) {
+                                var lineDiff = a.position.end.line - b.position.end.line;
+                                return lineDiff == 0 ? a.position.end.offset - b.position.end.offset : lineDiff;
+                            });
+
+                            var annotatedSentence = annotateDocument(allErrors);
+                            var errorDiv = $('<div></div>').addClass('redpen-error-section');
+                            var errorList = $('<ol></ol>').addClass('redpen-error-list');
+                            results.append(errorDiv);
+                            $(errorDiv)
+                                    .append($('<p></p>')
+                                            .addClass('redpen-error-sentence')
+                                            .html(annotatedSentence)
+                                    )
+                                    .append(errorList);
+
+                            for (var j = 0; j < allErrors.length; j++) {
+                                addError(errorList, allErrors[j]);
                             }
                         }
                         else {

--- a/redpen-server/src/main/webapp/index.html
+++ b/redpen-server/src/main/webapp/index.html
@@ -125,8 +125,8 @@ $(document).ready(function () {
                                                                 .prop("checked", true)
                                                                 .prop("value", validator.name)
                                                 )
-                                                .append(validator.name +
-                                                        (validator.languages.length ? ' <i>' + validator.languages.join(',') + '</i>' : '')
+                                                .append($('<span></span>')
+                                                        .html(validator.name + (validator.languages.length ? ' <i>' + validator.languages.join(',') + '</i>' : ''))
                                                 )
                                 )
                 );
@@ -216,7 +216,7 @@ $(document).ready(function () {
             }
         };
 
-        // cheap tabs - bootstraps were a somewhat visually heavy
+        // cheap tabs
         $("#redpen-option-results li").click(function () {
             $(this).siblings().each(function (i, item) {
                 $(this).removeClass("redpen-option-selected");
@@ -225,6 +225,193 @@ $(document).ready(function () {
             $($(this).data("target")).show();
             $(this).addClass("redpen-option-selected");
         });
+
+        // format RedPen errors in situ
+        var showErrorsInSitu = function (errors) {
+            if (errors.length) {
+                // get a list of the checked validators
+                var validators = {};
+                $("#redpen-active-validators").find("input:checked").each(function () {
+                    validators[$(this).val()] = true;
+                });
+
+                // display the errors
+                var results = $('#redpen-results')
+                        .empty()
+                        .append($('<h4></h4>')
+                                .html('<span class="redpen-red">Red</span>Pen found the following errors:')
+                        );
+
+                var addError = function (errorList, error) {
+                    if (validators[error.validator]) {
+                        $(errorList).append($('<li></li>')
+                                .addClass('redpen-error-message')
+                                .toggleClass('redpen-error-message-annotated', error.annotated)
+                                .text(error.message)
+                                .mouseenter(function () {
+                                    highlightEditor(error);
+                                })
+                                .mouseleave(function () {
+                                    highlightEditor(false);
+                                })
+                                .append($("<div></div>")
+                                        .addClass('redpen-error-validator')
+                                        .text(error.validator)
+                                )
+                        )
+                    }
+                };
+
+                var annotateDocument = function (errors) {
+                    var lines = getSourceLines();
+                    var annotated = [];
+                    for (var i = 1; i < lines.length; i++) {
+                        var sentence = lines[i];
+                        annotated[i] = [];
+                        for (var j = 0; j < sentence.length; j++) {
+                            annotated[i].push({char: sentence[j], errorStart: [], errorEnd: []});
+                        }
+                    }
+                    for (var i = 0; i < errors.length; i++) {
+                        if (validators[errors[i].validator]) {
+                            var lineNo = errors[i].position.end.line;
+                            if (lineNo < lines.length) {
+                                var sentence = lines[lineNo];
+                                var start = errors[i].position.start.offset ? errors[i].position.start.offset : 0;
+                                var end = errors[i].position.end.offset ? errors[i].position.end.offset : 0;
+                                if ((start != 0) || (end != 0)) {
+                                    if (annotated[lineNo][start]) {
+                                        annotated[lineNo][start].errorStart.push({id: i + 1, error: errors[i]});
+                                    }
+                                    errors[i].annotated = true;
+                                }
+                                if (annotated[lineNo] && annotated[lineNo][end]) {
+                                    annotated[lineNo][end].errorEnd.push({id: i + 1, error: errors[i]});
+                                    errors[i].annotated = true;
+                                }
+                            }
+                        }
+                    }
+
+                    // renderer the errors as HTML
+                    var annotatedSpan = $("<span></span>").addClass("redpen-annotated-sentence");
+                    var text = "";
+                    var errorOpen = false;
+                    var addText = function (highlight) {
+                        $(annotatedSpan).append($(highlight ? "<i></i>" : "<span></span>").text(text));
+                        text = "";
+                    };
+                    for (var line = 1; line < annotated.length; line++) {
+                        if (line != 1) {
+                            addText(false);
+                            $(annotatedSpan).append("<br/>");
+                        }
+                        for (var i = 0; i < annotated[line].length; i++) {
+                            if (errorOpen && annotated[line][i].errorEnd.length) {
+                                addText(true);
+                                errorOpen = false;
+                            }
+                            for (var j = 0; j < annotated[line][i].errorEnd.length; j++) {
+                                addText(false);
+                                $(annotatedSpan).append(
+                                        $('<b></b>')
+                                                .text(annotated[line][i].errorEnd[j].id)
+                                                .attr("data-toggle", "tooltip")
+                                                .prop("title", annotated[line][i].errorEnd[j].error.message.replace(/"/g, "'"))
+                                );
+                            }
+                            if (annotated[line][i].errorStart.length) {
+                                addText(false);
+                                errorOpen = true;
+                            }
+                            if (errorOpen && annotated[line][i].errorEnd.length) {
+                                addText(true);
+                                errorOpen = false;
+                            }
+                            text += annotated[line][i].char;
+                        }
+                    }
+                    addText();
+                    return $(annotatedSpan);
+                };
+
+                var allErrors = [];
+                for (var i = 0; i < errors.length; i++) {
+                    for (var j = 0; j < errors[i].errors.length; j++) {
+                        allErrors.push(errors[i].errors[j]);
+                    }
+                }
+                allErrors.sort(function (a, b) {
+                    var lineDiff = a.position.end.line - b.position.end.line;
+                    return lineDiff == 0 ? a.position.end.offset - b.position.end.offset : lineDiff;
+                });
+
+                var annotatedSentence = annotateDocument(allErrors);
+                var errorDiv = $('<div></div>').addClass('redpen-error-section');
+                var errorList = $('<ol></ol>').addClass('redpen-error-list');
+                results.append(errorDiv);
+                $(errorDiv)
+                        .append($('<p></p>')
+                                .addClass('redpen-error-sentence')
+                                .html(annotatedSentence)
+                        )
+                        .append(errorList);
+
+                for (var j = 0; j < allErrors.length; j++) {
+                    addError(errorList, allErrors[j]);
+                }
+                $('[data-toggle="tooltip"]').tooltip(
+                        {
+                            placement: "bottom",
+                            trigger: "hover click",
+                            animation: false,
+                            delay: 5
+                        }
+                );
+            }
+            else {
+                $('#redpen-results')
+                        .empty()
+                        .append($('<h4></h4>')
+                                .html('<span class="redpen-red">Red</span>Pen found no errors.')
+                        );
+            }
+        };
+
+        // sample "plain text" report
+        var createRedPenReport = function (errors) {
+            var report = "";
+            var contextWidth = 12;
+            if (errors) {
+                var formatError = function (sentence, error) {
+                    var message = "";
+                    message += "@" + error.position.start.line + ":" + error.position.start.offset + " ";
+                    var left = Math.max(0, error.subsentence.offset - contextWidth);
+                    var right = Math.min(sentence.length, error.subsentence.offset + error.subsentence.length + contextWidth);
+                    message += left == 0 ? "" : "\u2026";
+
+                    message += sentence.substring(left, error.subsentence.offset);
+                    message += error.subsentence.length ? "\u3010" : "\u25b6";
+                    message += sentence.substr(error.subsentence.offset, error.subsentence.length);
+                    message += error.subsentence.length ? "\u3011" : "";
+                    message += sentence.substring(error.subsentence.offset + error.subsentence.length, right);
+
+                    message += right == sentence.length ? "" : "\u2026";
+                    message += "\n";
+                    message += error.message;
+                    message += "\n";
+                    return message;
+                };
+                for (var i = 0; i < errors.length; i++) {
+                    var error = errors[i];
+                    for (j = 0; j < error.errors.length; j++) {
+                        report += formatError(error.sentence, error.errors[j]);
+                        report += '\n';
+                    }
+                }
+            }
+            return report;
+        };
 
         // call RedPen to validate the document and display any errors
         var validateDocument = function () {
@@ -235,138 +422,13 @@ $(document).ready(function () {
                         documentParser: $(documentParserSelect).val()
                     },
                     function (data) {
-                        $('#redpen-results-json').text(JSON.stringify(data, null, 1));
-                        var errors = data['errors'];
-                        if (errors.length) {
-                            // get a list of the checked validators
-                            var validators = {};
-                            $("#redpen-active-validators").find("input:checked").each(function () {
-                                validators[$(this).val()] = true;
-                            });
 
-                            // display the errors
-                            var results = $('#redpen-results')
-                                    .empty()
-                                    .append($('<h4></h4>')
-                                            .html('<span class="redpen-red">Red</span>Pen found the following errors:')
-                                    );
+                        // display the raw results as JSON
+                        $('#redpen-results-json').text(JSON.stringify(data, null, 2));
 
-                            var addError = function (errorList, error) {
-                                if (validators[error.validator]) {
-                                    $(errorList).append($('<li></li>')
-                                            .addClass('redpen-error-message')
-                                            .toggleClass('redpen-error-message-annotated', error.annotated)
-                                            .append(error.message)
-                                            .mouseenter(function () {
-                                                highlightEditor(error);
-                                            })
-                                            .mouseleave(function () {
-                                                highlightEditor(false);
-                                            })
-                                            .append($("<div></div>")
-                                                    .addClass('redpen-error-validator')
-                                                    .text(error.validator)
-                                            )
-                                    )
-                                }
-                            };
+                        showErrorsInSitu(data['errors']);
 
-                            var annotateDocument = function (errors) {
-                                var lines = getSourceLines();
-                                var annotated = [];
-                                for (var i = 1; i < lines.length; i++) {
-                                    var sentence = lines[i];
-                                    annotated[i] = [];
-                                    for (var j = 0; j < sentence.length; j++) {
-                                        annotated[i].push({char: sentence[j], errorStart: [], errorEnd: []});
-                                    }
-                                }
-                                for (var i = 0; i < errors.length; i++) {
-                                    var lineNo = errors[i].position.end.line;
-                                    if (lineNo < lines.length) {
-                                        var sentence = lines[lineNo];
-                                        var start = errors[i].position.start.offset ? errors[i].position.start.offset : 0;
-                                        var end = errors[i].position.end.offset ? errors[i].position.end.offset : 0;
-                                        if ((start != 0) || (end != 0)) {
-                                            if (annotated[lineNo][start]) {
-                                                annotated[lineNo][start].errorStart.push({id: i + 1, error: errors[i]});
-                                            }
-                                            errors[i].annotated = true;
-                                        }
-                                        if (annotated[lineNo][end]) {
-                                            annotated[lineNo][end].errorEnd.push({id: i + 1, error: errors[i]});
-                                            errors[i].annotated = true;
-                                        }
-
-                                    }
-                                }
-
-                                // renderer the errors as HTML
-                                var html = "";
-                                var errorOpen = false;
-                                for (var line = 1; line < annotated.length; line++) {
-                                    if (line != 1) {
-                                        html += "<br/>";
-                                    }
-                                    for (var i = 0; i < annotated[line].length; i++) {
-                                        if (errorOpen && annotated[line][i].errorEnd.length) {
-                                            html += "</i>";
-                                            errorOpen = false;
-                                        }
-                                        for (var j = 0; j < annotated[line][i].errorEnd.length; j++) {
-                                            html += "<b>" + annotated[line][i].errorEnd[j].id + "</b>";
-                                        }
-                                        if (annotated[line][i].errorStart.length) {
-                                            html += "<i>";
-                                            errorOpen = true;
-                                        }
-                                        if (errorOpen && annotated[line][i].errorEnd.length) {
-                                            html += "</i>";
-                                            errorOpen = false;
-                                        }
-                                        html += annotated[line][i].char;
-                                    }
-                                }
-
-                                return $("<span></span>").addClass("redpen-annotated-sentence").html(html);
-                            };
-
-                            var allErrors = [];
-                            for (var i = 0; i < errors.length; i++) {
-                                for (var j = 0; j < errors[i].errors.length; j++) {
-                                    // TODO: Consider putting absolute positions in the errors rather than sentence relative ones?
-                                    errors[i].errors[j].position.start.offset += errors[i].position.start.offset;
-                                    errors[i].errors[j].position.end.offset += errors[i].position.start.offset;
-                                    allErrors.push(errors[i].errors[j]);
-                                }
-                            }
-                            allErrors.sort(function (a, b) {
-                                var lineDiff = a.position.end.line - b.position.end.line;
-                                return lineDiff == 0 ? a.position.end.offset - b.position.end.offset : lineDiff;
-                            });
-
-                            var annotatedSentence = annotateDocument(allErrors);
-                            var errorDiv = $('<div></div>').addClass('redpen-error-section');
-                            var errorList = $('<ol></ol>').addClass('redpen-error-list');
-                            results.append(errorDiv);
-                            $(errorDiv)
-                                    .append($('<p></p>')
-                                            .addClass('redpen-error-sentence')
-                                            .html(annotatedSentence)
-                                    )
-                                    .append(errorList);
-
-                            for (var j = 0; j < allErrors.length; j++) {
-                                addError(errorList, allErrors[j]);
-                            }
-                        }
-                        else {
-                            $('#redpen-results')
-                                    .empty()
-                                    .append($('<h4></h4>')
-                                            .html('<span class="redpen-red">Red</span>Pen found no errors.')
-                                    );
-                        }
+                        $('#redpen-results-report').text(createRedPenReport(data['errors']));
                     });
         };
 
@@ -461,16 +523,17 @@ $(document).ready(function () {
     <div class="container redpen-fixed-container">
 
         <div class="row redpen-header-row">
-            <div class="col-md-8">
+            <div class="col-md-7">
                 <h1>Welcome to <span class="redpen-red">Red</span>Pen!</h1>
 
                 <p>To try the <span class="redpen-red">Red</span>Pen validator, please type or paste some text into
                     the first box.</p>
             </div>
 
-            <div class="col-md-2">
+            <div class="col-md-3">
                 <ul id="redpen-option-results">
                     <li data-target='#redpen-results' class="redpen-option-selected">Errors</li>
+                    <li data-target='#redpen-results-report'>Report</li>
                     <li data-target='#redpen-results-json'>JSON</li>
                 </ul>
             </div>
@@ -484,6 +547,8 @@ $(document).ready(function () {
             </div>
             <div class="col-md-5">
                 <div id="redpen-results" class="well">
+                </div>
+                <div id="redpen-results-report" style="display:none" class="well">
                 </div>
                 <div id="redpen-results-json" style="display:none" class="well">
                 </div>


### PR DESCRIPTION
* Rewrote PlainTextParser to parse in such a way that a LineOffset map could be constructed whilst parsing, meaning offset lookups for token positions now match their position in the source text.
* Offsets generated for plain text documents are now relative to the line, rather than the sentence, as they are for Markdown/WIKI documents.
* Added Sentence.getOffsetPosition() method to do a reverse lookup of a LineOffset and provide its position in Sentence.getContent()’s string.
* Added “subsentence” element to JSON2 format to help implementers display the error within the sentence text provided in the JSON in case access to the source text is difficult in-situ.
* Added test cases for new functionality
* Patched faulty append() of source document text in jQuery
* Updated UI to match the changes to document parsing and JSON2 representation
* Added tooltips to in-situ markers to show the relevant error message
* Modified KatakanaEndHyphenValidator to record the position of the erroneous hyphen
* Added simple plain text report example to the GUI demonstrating the use of normalized sentence to assist error reporting
* Fixed ArrayIndexOutOfBoundsException in Sentence.getOffset() when offsetMap was currently empty and the position requested was zero, or when index was negative where offsets for empty sentences were requested.
