### PR TITLE
configuration-immutable

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/ConfigurationLoader.java
+++ b/redpen-core/src/main/java/cc/redpen/ConfigurationLoader.java
@@ -240,7 +240,7 @@ public final class ConfigurationLoader {
             if (nNode.getNodeType() == Node.ELEMENT_NODE) {
                 Element element = (Element) nNode;
                 Symbol currentSymbol = createSymbol(element);
-                configBuilder.setSymbol(currentSymbol);
+                configBuilder.addSymbol(currentSymbol);
             }
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -93,31 +93,43 @@ public final class Configuration {
     public static class ConfigurationBuilder {
         private final List<ValidatorConfiguration> validatorConfigs = new ArrayList<>();
         private final List<Symbol> customSymbols = new ArrayList<>();
+        private boolean built = false;
 
         private String lang = "en";
         private Optional<String> type = Optional.empty();
 
+        private void checkBuilt(){
+            if(built){
+                throw new IllegalStateException("Configuration already built.");
+            }
+        }
         public ConfigurationBuilder setLanguage(String lang) {
+            checkBuilt();
             this.lang = lang;
             return this;
         }
 
         public ConfigurationBuilder setSymbol(Symbol symbol) {
+            checkBuilt();
             customSymbols.add(symbol);
             return this;
         }
 
         public ConfigurationBuilder addValidatorConfig(ValidatorConfiguration config) {
+            checkBuilt();
             validatorConfigs.add(config);
             return this;
         }
 
         public ConfigurationBuilder setType(String type) {
+            checkBuilt();
             this.type = Optional.of(type);
             return this;
         }
 
         public Configuration build() {
+            checkBuilt();
+            built = true;
             return new Configuration(new SymbolTable(lang, type, customSymbols), this.validatorConfigs, this.lang);
         }
     }

--- a/redpen-core/src/main/java/cc/redpen/config/Configuration.java
+++ b/redpen-core/src/main/java/cc/redpen/config/Configuration.java
@@ -109,7 +109,7 @@ public final class Configuration {
             return this;
         }
 
-        public ConfigurationBuilder setSymbol(Symbol symbol) {
+        public ConfigurationBuilder addSymbol(Symbol symbol) {
             checkBuilt();
             customSymbols.add(symbol);
             return this;

--- a/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/MarkdownParserTest.java
@@ -859,8 +859,8 @@ public class MarkdownParserTest {
                 "以下のとおりである．";
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .setLanguage("ja")
-                .setSymbol(new Symbol(FULL_STOP, '．', "."))
-                .setSymbol(new Symbol(COMMA, '，', "、"))
+                .addSymbol(new Symbol(FULL_STOP, '．', "."))
+                .addSymbol(new Symbol(COMMA, '，', "、"))
                 .build();
 
         Document doc = createFileContent(sampleText, conf);

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationRedPenBuilderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationRedPenBuilderTest.java
@@ -105,7 +105,7 @@ public class ConfigurationRedPenBuilderTest {
         Configuration config = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .setLanguage("ja")
-                .setSymbol(new Symbol(FULL_STOP, '.'))
+                .addSymbol(new Symbol(FULL_STOP, '.'))
                 .build();
 
         assertNotNull(config.getSymbolTable());
@@ -118,7 +118,7 @@ public class ConfigurationRedPenBuilderTest {
         Configuration config = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .setLanguage("ja")
-                .setSymbol(new Symbol(SymbolType.FULL_STOP, '。', ".．●"))
+                .addSymbol(new Symbol(SymbolType.FULL_STOP, '。', ".．●"))
                 .build();
 
         assertNotNull(config.getSymbolTable());
@@ -133,7 +133,7 @@ public class ConfigurationRedPenBuilderTest {
         Configuration config = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidExpression"))
                 .setLanguage("ja")
-                .setSymbol(new Symbol(SymbolType.FULL_STOP, '。', ".．●"))
+                .addSymbol(new Symbol(SymbolType.FULL_STOP, '。', ".．●"))
                 .build();
 
         assertNotNull(config.getSymbolTable());

--- a/redpen-core/src/test/java/cc/redpen/config/ConfigurationRedPenBuilderTest.java
+++ b/redpen-core/src/test/java/cc/redpen/config/ConfigurationRedPenBuilderTest.java
@@ -145,4 +145,13 @@ public class ConfigurationRedPenBuilderTest {
         assertTrue(new String(config.getSymbolTable()
                 .getSymbolByValue('。').getInvalidChars()).contains("●"));
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBuildTwice(){
+        Configuration.ConfigurationBuilder builder = new Configuration.ConfigurationBuilder();
+        builder.setLanguage("en");
+        builder.build();
+        // ConfigurationBuilder is not designed to build more than one RedPen instance
+        builder.setLanguage("ja");
+    }
 }

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/InvalidSymbolValidatorTest.java
@@ -52,7 +52,7 @@ public class InvalidSymbolValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
+                .addSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
                 .build();
 
         RedPen redPen = new RedPen(conf);
@@ -75,7 +75,7 @@ public class InvalidSymbolValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
+                .addSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
                 .build();
 
         RedPen redPen = new RedPen(conf);
@@ -97,8 +97,8 @@ public class InvalidSymbolValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
-                .setSymbol(new Symbol(COMMA, ',', "、"))
+                .addSymbol(new Symbol(EXCLAMATION_MARK, '!', "！"))
+                .addSymbol(new Symbol(COMMA, ',', "、"))
                 .build();
 
         RedPen redPen = new RedPen(conf);

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/QuotationValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/QuotationValidatorTest.java
@@ -284,7 +284,7 @@ public class QuotationValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .setLanguage("en")
                 .addValidatorConfig(new ValidatorConfiguration("Quotation").addAttribute("use_ascii", true))
-                .setSymbol(new Symbol(SymbolType.FULL_STOP, '。'))
+                .addSymbol(new Symbol(SymbolType.FULL_STOP, '。'))
                 .build();
         Validator validator = ValidatorFactory.getInstance(conf.getValidatorConfigs().get(0), conf.getSymbolTable());
 

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/SymbolWithSpaceValidatorTest.java
@@ -51,7 +51,7 @@ public class SymbolWithSpaceValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(SLASH, '/'))
+                .addSymbol(new Symbol(SLASH, '/'))
                 .build();
 
         RedPen redPen = new RedPen(conf);
@@ -72,7 +72,7 @@ public class SymbolWithSpaceValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(COLON, ':', "", false, true))
+                .addSymbol(new Symbol(COLON, ':', "", false, true))
                 .build();
 
         RedPen redPen = new RedPen(conf);
@@ -93,7 +93,7 @@ public class SymbolWithSpaceValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(LEFT_PARENTHESIS, '(', "", true, false))
+                .addSymbol(new Symbol(LEFT_PARENTHESIS, '(', "", true, false))
                 .build();
 
         RedPen redPen = new RedPen(conf);
@@ -114,8 +114,8 @@ public class SymbolWithSpaceValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(LEFT_PARENTHESIS, '(', "", true, false))
-                .setSymbol(new Symbol(RIGHT_PARENTHESIS, ')', "", false, true))
+                .addSymbol(new Symbol(LEFT_PARENTHESIS, '(', "", true, false))
+                .addSymbol(new Symbol(RIGHT_PARENTHESIS, ')', "", false, true))
                 .build();
 
         RedPen redPen = new RedPen(conf);
@@ -136,7 +136,7 @@ public class SymbolWithSpaceValidatorTest {
         Configuration conf = new Configuration.ConfigurationBuilder()
                 .addValidatorConfig(new ValidatorConfiguration("SymbolWithSpace"))
                 .setLanguage("en")
-                .setSymbol(new Symbol(ASTERISK, '*', "", true, true))
+                .addSymbol(new Symbol(ASTERISK, '*', "", true, true))
                 .build();
 
         RedPen redPen = new RedPen(conf);


### PR DESCRIPTION
ConfigurationBuilder mutation methods now throw IllegalStateException after calling build().

ConfigurationBuilder is not designed to build more than one RedPen instance.
Adding validatorConfig / symbol to ConfigurationBuilder could effect existing RedPen instance.