### PR TITLE
[WIP] Add plugin module but it failed to load properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
     <modules>
         <module>redpen-core</module>
+        <module>redpen-plugin</module>
         <module>redpen-cli</module>
         <module>redpen-server</module>
     </modules>

--- a/redpen-cli/pom.xml
+++ b/redpen-cli/pom.xml
@@ -71,6 +71,12 @@
             <version>1.2</version>
         </dependency>
         <dependency>
+            <groupId>cc.redpen</groupId>
+            <artifactId>redpen-plugin</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>

--- a/redpen-cli/sample/conf/redpen-conf-plugin.xml
+++ b/redpen-cli/sample/conf/redpen-conf-plugin.xml
@@ -1,0 +1,5 @@
+<redpen-conf lang="en">
+    <validators>
+        <validator name="SamplePlugin"/>
+    </validators>
+</redpen-conf>

--- a/redpen-cli/src/test/java/cc/redpen/MainTest.java
+++ b/redpen-cli/src/test/java/cc/redpen/MainTest.java
@@ -22,9 +22,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 public class MainTest {
 
@@ -60,6 +58,15 @@ public class MainTest {
         // environment variable cannot be set via Java program
     }
 
+    @Test
+    public void testPlugin() throws Exception {
+        String[] args = new String[]{
+                "-c", "sample/conf/redpen-conf-plugin.xml",
+                "sample/sample-doc/en/sampledoc-en.txt",
+                "-l", "100"
+        };
+        assertEquals(0, Main.run(args));
+    }
 
     @Test
     public void testMainWithoutParameters() throws RedPenException {

--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -30,7 +30,6 @@ import cc.redpen.util.DictionaryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.text.MessageFormat;
 import java.util.*;
 

--- a/redpen-plugin/pom.xml
+++ b/redpen-plugin/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>redpen</artifactId>
+        <groupId>cc.redpen</groupId>
+        <version>1.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>redpen-plugin</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>cc.redpen</groupId>
+            <artifactId>redpen-core</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/redpen-plugin/src/main/java/cc/redpen/validator/sentence/SamplePluginValidator.java
+++ b/redpen-plugin/src/main/java/cc/redpen/validator/sentence/SamplePluginValidator.java
@@ -1,0 +1,16 @@
+package cc.redpen.validator.sentence;
+
+import cc.redpen.model.Sentence;
+import cc.redpen.validator.ValidationError;
+import cc.redpen.validator.Validator;
+
+import java.util.List;
+
+public class SamplePluginValidator extends Validator {
+    @Override
+    public void validate(List<ValidationError> errors, Sentence sentence) {
+        if (sentence.getContent().length() < 100) {
+            errors.add(createValidationError(sentence, sentence.getContent().length(), 10));
+        }
+    }
+}

--- a/redpen-plugin/src/main/resources/cc/redpen/validator/sentence/error-messages.properties
+++ b/redpen-plugin/src/main/resources/cc/redpen/validator/sentence/error-messages.properties
@@ -1,0 +1,1 @@
+SamplePluginValidator=too short.

--- a/redpen-plugin/src/main/resources/cc/redpen/validator/sentence/error-messages_ja.properties
+++ b/redpen-plugin/src/main/resources/cc/redpen/validator/sentence/error-messages_ja.properties
@@ -1,0 +1,1 @@
+SamplePluginValidator=短い。


### PR DESCRIPTION
I would like to add a module for a sample of RedPen plugin, but currently the build is failed because of failing to load the properties for plugin error messages.
```
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key SamplePluginValidator
        at java.util.ResourceBundle.getObject(ResourceBundle.java:450)
        at java.util.ResourceBundle.getString(ResourceBundle.java:407)
        at cc.redpen.validator.Validator.getLocalizedErrorMessage(Validator.java:273)
        at cc.redpen.validator.Validator.createValidationError(Validator.java:203)
        at cc.redpen.validator.sentence.SamplePluginValidator.valida
```

Any comments would be appreciate it.
