### PR TITLE
AsciiDoc Parser support

### DIFF
--- a/redpen-core/pom.xml
+++ b/redpen-core/pom.xml
@@ -157,6 +157,16 @@
             <artifactId>pegdown</artifactId>
             <version>1.4.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>1.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/redpen-core/src/main/java/cc/redpen/model/Sentence.java
+++ b/redpen-core/src/main/java/cc/redpen/model/Sentence.java
@@ -222,8 +222,8 @@ public final class Sentence implements Serializable {
             if (offsetMap.size() > position) {
                 return Optional.of(offsetMap.get(position));
             } else if ((position > 0) && (offsetMap.size() == position)) {
-                LineOffset prev = offsetMap.get(position - 1);
-                return Optional.of(new LineOffset(prev.lineNum, prev.offset + 1));
+                LineOffset last = offsetMap.get(offsetMap.size() - 1);
+                return Optional.of(new LineOffset(last.lineNum, last.offset + 1));
             }
             return Optional.of(new LineOffset(lineNumber, position));
         }

--- a/redpen-core/src/main/java/cc/redpen/parser/AsciiDocParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/AsciiDocParser.java
@@ -21,24 +21,117 @@ package cc.redpen.parser;
 import cc.redpen.RedPenException;
 import cc.redpen.model.Document;
 import cc.redpen.tokenizer.RedPenTokenizer;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.RedPenTreeProcessor;
+import org.pegdown.ParsingTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 
 /**
- * Parser for AsciiDoc format.<br/>
+ * Parser for AsciiDoc format, utilizing AsciiDoctorJ.<br/>
  * <p/>
- * AsciiDoc's syntax and grammar is document at @see http://asciidoc.org/
+ * AsciiDoc's syntax and grammar is documented at @see http://asciidoc.org/
  */
 public class AsciiDocParser extends BaseDocumentParser {
+    private static final Logger LOG = LoggerFactory.getLogger(AsciiDocParser.class);
 
     @Override
     public Document parse(InputStream io, Optional<String> fileName, SentenceExtractor sentenceExtractor, RedPenTokenizer tokenizer) throws RedPenException {
         Document.DocumentBuilder documentBuilder = new Document.DocumentBuilder(tokenizer);
+        fileName.ifPresent(documentBuilder::setFileName);
+        BufferedReader reader = createReader(io);
+        try {
+            Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+            InputStream rubySource = new ByteArrayInputStream(AsciiDoctorRedPenRubySource.SOURCE_TEXT.getBytes("UTF-8"));
+            asciidoctor.rubyExtensionRegistry().loadClass(rubySource);
+            Map<String, Object> options = new HashMap<>();
+            options.put("backend", "redpen");
+            options.put("sourcemap", true);
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put("sourcemap", true);
+            options.put("attributes", attributes);
 
-        // CURRENTLY THERE IS NO ASCIIDOC IMPLEMENTATION
+            // Register our documentbuilding TreeProcessor
+            asciidoctor.javaExtensionRegistry().treeprocessor(new RedPenTreeProcessor(documentBuilder, sentenceExtractor, options));
+
+            try {
+                // trigger the tree processor, which will consequently fill the documentBuilder
+                asciidoctor.readDocumentStructure(reader, options);
+            } catch (Exception e) {
+                LOG.error("Asciidoctor parser error: " + e.getMessage());
+            }
+
+        } catch (ParsingTimeoutException e) {
+            throw new RedPenException("Failed to parse timeout: ", e);
+        } catch (Exception e) {
+            throw new RedPenException("Exception when configuring AsciiDoctor", e);
+        }
 
         return documentBuilder.build();
     }
+}
+
+class AsciiDoctorRedPenRubySource {
+    public static String SOURCE_TEXT = "# encoding: UTF-8\n" +
+            "module Asciidoctor\n" +
+            "  class Converter::RedPen < Converter::BuiltIn\n" +
+            "    def initialize backend, opts = {}\n" +
+            "    end\n" +
+            "    def redpen_output node, opts = {}\n" +
+            "      location=''\n" +
+            "      if defined?(node.source_location) && (node.source_location != nil)\n" +
+            "        location = \"\\001#{node.source_location.lineno}\\002\"\n" +
+            "      end\n" +
+            "      content = defined?(node.text) ? node.text : (defined?(node.content) ? node.content : '')\n" +
+            "      \"#{location}#{content}\"\n" +
+            "    end\n" +
+            "    alias content redpen_output\n" +
+            "    alias paragraph redpen_output\n" +
+            "    alias document redpen_output\n" +
+            "    alias embedded redpen_output\n" +
+            "    alias outline redpen_output\n" +
+            "    alias section redpen_output\n" +
+            "    alias admonition redpen_output\n" +
+            "    alias audio redpen_output\n" +
+            "    alias colist redpen_output\n" +
+            "    alias dlist redpen_output\n" +
+            "    alias example redpen_output\n" +
+            "    alias floating_title redpen_output\n" +
+            "    alias image redpen_output\n" +
+            "    alias listing redpen_output\n" +
+            "    alias literal redpen_output\n" +
+            "    alias stem redpen_output\n" +
+            "    alias olist redpen_output\n" +
+            "    alias open redpen_output\n" +
+            "    alias page_break redpen_output\n" +
+            "    alias preamble redpen_output\n" +
+            "    alias quote redpen_output\n" +
+            "    alias thematic_break redpen_output\n" +
+            "    alias sidebar redpen_output\n" +
+            "    alias table redpen_output\n" +
+            "    alias toc redpen_output\n" +
+            "    alias ulist redpen_output\n" +
+            "    alias verse redpen_output\n" +
+            "    alias video redpen_output\n" +
+            "    alias inline_anchor redpen_output\n" +
+            "    alias inline_break redpen_output\n" +
+            "    alias inline_button redpen_output\n" +
+            "    alias inline_callout redpen_output\n" +
+            "    alias inline_footnote redpen_output\n" +
+            "    alias inline_image redpen_output\n" +
+            "    alias inline_indexterm redpen_output\n" +
+            "    alias inline_kbd redpen_output\n" +
+            "    alias inline_menu redpen_output\n" +
+            "    alias inline_quoted redpen_output\n" +
+            "  end\n" +
+            "  Asciidoctor::Converter::Factory.register Asciidoctor::Converter::RedPen, [\"redpen\"]\n" +
+            "end\n";
 }

--- a/redpen-core/src/main/java/cc/redpen/parser/AsciiDocParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/AsciiDocParser.java
@@ -64,6 +64,7 @@ public class AsciiDocParser extends BaseDocumentParser {
 
             try {
                 // trigger the tree processor, which will consequently fill the documentBuilder
+
                 asciidoctor.readDocumentStructure(reader, options);
             } catch (Exception e) {
                 LOG.error("Asciidoctor parser error: " + e.getMessage());
@@ -82,56 +83,66 @@ public class AsciiDocParser extends BaseDocumentParser {
 class AsciiDoctorRedPenRubySource {
     public static String SOURCE_TEXT = "# encoding: UTF-8\n" +
             "module Asciidoctor\n" +
-            "  class Converter::RedPen < Converter::BuiltIn\n" +
-            "    def initialize backend, opts = {}\n" +
-            "    end\n" +
-            "    def redpen_output node, opts = {}\n" +
-            "      location=''\n" +
-            "      if defined?(node.source_location) && (node.source_location != nil)\n" +
-            "        location = \"\\001#{node.source_location.lineno}\\002\"\n" +
-            "      end\n" +
-            "      content = defined?(node.text) ? node.text : (defined?(node.content) ? node.content : '')\n" +
-            "      \"#{location}#{content}\"\n" +
-            "    end\n" +
-            "    alias content redpen_output\n" +
-            "    alias paragraph redpen_output\n" +
-            "    alias document redpen_output\n" +
-            "    alias embedded redpen_output\n" +
-            "    alias outline redpen_output\n" +
-            "    alias section redpen_output\n" +
-            "    alias admonition redpen_output\n" +
-            "    alias audio redpen_output\n" +
-            "    alias colist redpen_output\n" +
-            "    alias dlist redpen_output\n" +
-            "    alias example redpen_output\n" +
-            "    alias floating_title redpen_output\n" +
-            "    alias image redpen_output\n" +
-            "    alias listing redpen_output\n" +
-            "    alias literal redpen_output\n" +
-            "    alias stem redpen_output\n" +
-            "    alias olist redpen_output\n" +
-            "    alias open redpen_output\n" +
-            "    alias page_break redpen_output\n" +
-            "    alias preamble redpen_output\n" +
-            "    alias quote redpen_output\n" +
-            "    alias thematic_break redpen_output\n" +
-            "    alias sidebar redpen_output\n" +
-            "    alias table redpen_output\n" +
-            "    alias toc redpen_output\n" +
-            "    alias ulist redpen_output\n" +
-            "    alias verse redpen_output\n" +
-            "    alias video redpen_output\n" +
-            "    alias inline_anchor redpen_output\n" +
-            "    alias inline_break redpen_output\n" +
-            "    alias inline_button redpen_output\n" +
-            "    alias inline_callout redpen_output\n" +
-            "    alias inline_footnote redpen_output\n" +
-            "    alias inline_image redpen_output\n" +
-            "    alias inline_indexterm redpen_output\n" +
-            "    alias inline_kbd redpen_output\n" +
-            "    alias inline_menu redpen_output\n" +
-            "    alias inline_quoted redpen_output\n" +
+            "class Converter::RedPen < Converter::BuiltIn\n" +
+
+            "def initialize backend, opts = {}\n" +
+            "end\n" +
+
+            "def redpen_output node, opts = {}\n" +
+            "  location=''\n" +
+            "  if defined?(node.source_location) && (node.source_location != nil)\n" +
+            "    location = \"\\001#{node.source_location.lineno}\\002\"\n" +
             "  end\n" +
-            "  Asciidoctor::Converter::Factory.register Asciidoctor::Converter::RedPen, [\"redpen\"]\n" +
+            "  content = defined?(node.content) ? node.content : (defined?(node.text) ? node.text : '')\n" +
+            "  \"#{location}\\003#{content}\\004\"\n" +
+            "end\n" +
+
+            "alias paragraph redpen_output\n" +
+            "alias document redpen_output\n" +
+            "alias embedded redpen_output\n" +
+            "alias outline redpen_output\n" +
+            "alias section redpen_output\n" +
+            "alias admonition redpen_output\n" +
+            "alias audio redpen_output\n" +
+            "alias colist redpen_output\n" +
+            "alias dlist redpen_output\n" +
+            "alias example redpen_output\n" +
+            "alias floating_title redpen_output\n" +
+            "alias image redpen_output\n" +
+            "alias listing redpen_output\n" +
+            "alias literal redpen_output\n" +
+            "alias stem redpen_output\n" +
+            "alias olist redpen_output\n" +
+            "alias open redpen_output\n" +
+            "alias page_break redpen_output\n" +
+            "alias preamble redpen_output\n" +
+            "alias quote redpen_output\n" +
+            "alias thematic_break redpen_output\n" +
+            "alias sidebar redpen_output\n" +
+            "alias table redpen_output\n" +
+            "alias toc redpen_output\n" +
+            "alias ulist redpen_output\n" +
+            "alias verse redpen_output\n" +
+            "alias video redpen_output\n" +
+            "alias inline_anchor redpen_output\n" +
+            "alias inline_break redpen_output\n" +
+            "alias inline_button redpen_output\n" +
+            "alias inline_callout redpen_output\n" +
+            "alias inline_footnote redpen_output\n" +
+            "alias inline_image redpen_output\n" +
+            "alias inline_indexterm redpen_output\n" +
+            "alias inline_kbd redpen_output\n" +
+            "alias inline_menu redpen_output\n" +
+            "alias inline_quoted redpen_output\n" +
+            "end\n" +
+
+            "Asciidoctor::Converter::Factory.register Asciidoctor::Converter::RedPen, [\"redpen\"]\n" +
+
+            // need to prevent AsciiDoctor's substitutors from replacing quotes with fancy-quotes, and (c) with the &copy; etc
+            "Substitutors::SUBS[:basic]=[:specialcharacters]\n" +
+            "Substitutors::SUBS[:normal]=[:specialcharacters, :quotes, :attributes,  :macros, :post_replacements]\n" +
+            "Substitutors::SUBS[:verbatim]=[:specialcharacters, :callouts]\n" +
+            "Substitutors::SUBS[:title]=[:specialcharacters, :quotes, :macros, :attributes, :post_replacements]\n" +
+            "Substitutors::SUBS[:header]=[:specialcharacters, :attributes]\n" +
             "end\n";
 }

--- a/redpen-core/src/main/java/cc/redpen/parser/DocumentParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/DocumentParser.java
@@ -86,7 +86,7 @@ public interface DocumentParser {
     public static final DocumentParser PLAIN = new PlainTextParser();
     public static final DocumentParser WIKI = new WikiParser();
     public static final DocumentParser MARKDOWN = new MarkdownParser();
-    // public static final DocumentParser ASCIIDOC = new AsciiDocParser();
+    public static final DocumentParser ASCIIDOC = new AsciiDocParser();
 
     public static final Map<String, DocumentParser> PARSER_MAP = Collections.unmodifiableMap(
             new HashMap<String, DocumentParser>() {
@@ -94,7 +94,7 @@ public interface DocumentParser {
                     put("PLAIN", PLAIN);
                     put("WIKI", WIKI);
                     put("MARKDOWN", MARKDOWN);
-                    // put("ASCIIDOC", ASCIIDOC);
+                    put("ASCIIDOC", ASCIIDOC);
                 }
             });
 

--- a/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
+++ b/redpen-core/src/main/java/cc/redpen/parser/PlainTextParser.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 /**
  * Parser for plain text file.
  */
-final class PlainTextParser extends BaseDocumentParser implements Serializable {
+final public class PlainTextParser extends BaseDocumentParser implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(PlainTextParser.class);
     private static final long serialVersionUID = -4343255148183552844L;
 
@@ -88,13 +88,30 @@ final class PlainTextParser extends BaseDocumentParser implements Serializable {
 
 
     /* Add a sentence with offsets */
-    private LineOffset addSentence(LineOffset lineOffset, String rawSentenceText, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
+    public static LineOffset addSentence(LineOffset lineOffset, String rawSentenceText, SentenceExtractor sentenceExtractor, Document.DocumentBuilder builder) {
 
         int lineNum = lineOffset.lineNum;
         int offset = lineOffset.offset;
+
+        int sentenceStartLineNum = lineNum;
+        int sentenceStartLineOffset = offset;
+
         List<LineOffset> offsetMap = new ArrayList<>();
         String normalizedSentence = "";
-        for (int i = 0; i < rawSentenceText.length(); i++) {
+        int i;
+        // skip leading line breaks to find the start line of the sentence
+        for (i = 0; i < rawSentenceText.length(); i++) {
+            char ch = rawSentenceText.charAt(i);
+            if (ch == '\n') {
+                sentenceStartLineNum++;
+                lineNum++;
+                sentenceStartLineOffset = 0;
+                offset = 0;
+            } else {
+                break;
+            }
+        }
+        for (; i < rawSentenceText.length(); i++) {
             char ch = rawSentenceText.charAt(i);
             if (ch == '\n') {
                 if (!sentenceExtractor.getBrokenLineSeparator().isEmpty()) {
@@ -109,7 +126,7 @@ final class PlainTextParser extends BaseDocumentParser implements Serializable {
                 offset++;
             }
         }
-        Sentence sentence = new Sentence(normalizedSentence, lineNum, lineOffset.offset);
+        Sentence sentence = new Sentence(normalizedSentence, sentenceStartLineNum, sentenceStartLineOffset);
         sentence.setOffsetMap(offsetMap);
         builder.addSentence(sentence);
 

--- a/redpen-core/src/main/java/cc/redpen/validator/Validator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/Validator.java
@@ -30,7 +30,6 @@ import cc.redpen.util.DictionaryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.text.MessageFormat;
 import java.util.*;
 
@@ -297,6 +296,6 @@ public abstract class Validator {
     /**
      * Resource Extractor loads word list while lowercasing lines
      */
-    protected final static DictionaryLoader<Set<String>> WORD_LSIT_LOWERCASED =
+    protected final static DictionaryLoader<Set<String>> WORD_LIST_LOWERCASED =
             new DictionaryLoader<>(HashSet::new, (set, line) -> set.add(line.toLowerCase()));
 }

--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/SpellingValidator.java
@@ -47,7 +47,7 @@ public class SpellingValidator extends Validator {
     protected void init() throws RedPenException {
         String defaultDictionaryFile = DEFAULT_RESOURCE_PATH
                 + "/spellchecker-" + getSymbolTable().getLang() + ".dat";
-        defaultDictionary = WORD_LSIT_LOWERCASED.loadCachedFromResource(defaultDictionaryFile, "spell dictionary");
+        defaultDictionary = WORD_LIST_LOWERCASED.loadCachedFromResource(defaultDictionaryFile, "spell dictionary");
 
         customDictionary = new HashSet<>();
         Optional<String> listStr = getConfigAttribute("list");
@@ -60,7 +60,7 @@ public class SpellingValidator extends Validator {
         Optional<String> userDictionaryFile = getConfigAttribute("dict");
         if (userDictionaryFile.isPresent()) {
             String f = userDictionaryFile.get();
-            customDictionary.addAll(WORD_LSIT_LOWERCASED.loadCachedFromFile(new File(f), "SpellingValidator user dictionary"));
+            customDictionary.addAll(WORD_LIST_LOWERCASED.loadCachedFromFile(new File(f), "SpellingValidator user dictionary"));
         }
     }
 

--- a/redpen-core/src/main/java/org/asciidoctor/RedPenTreeProcessor.java
+++ b/redpen-core/src/main/java/org/asciidoctor/RedPenTreeProcessor.java
@@ -1,0 +1,154 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.asciidoctor;
+
+import cc.redpen.model.Section;
+import cc.redpen.model.Sentence;
+import cc.redpen.parser.LineOffset;
+import cc.redpen.parser.SentenceExtractor;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.BlockImpl;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.SectionImpl;
+import org.asciidoctor.extension.Treeprocessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AsciiDoctor tree processor, for use with the "redpen" AsciiDoctor backend, used to populate a RedPen document
+ * <p/>
+ * This (unfortunately) has to be under an 'org' or 'com' package, rather than a 'cc' package,
+ * due to the way JRuby and AsciiDoctor handle the registration of this class.
+ */
+public class RedPenTreeProcessor extends Treeprocessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedPenTreeProcessor.class);
+
+    private cc.redpen.model.Document.DocumentBuilder documentBuilder;
+    private SentenceExtractor sentenceExtractor;
+
+    private int lineNumber = 1;
+
+    public RedPenTreeProcessor(cc.redpen.model.Document.DocumentBuilder documentBuilder, SentenceExtractor sentenceExtractor, Map<String, Object> config) {
+        super(config);
+        this.documentBuilder = documentBuilder;
+        this.sentenceExtractor = sentenceExtractor;
+    }
+
+    @Override
+    public Document process(Document document) {
+        List<Sentence> headers = new ArrayList<>();
+        headers.add(new Sentence(document.doctitle() != null ? document.doctitle() : "", 0));
+        documentBuilder.appendSection(new Section(0, headers));
+        traverse(document.blocks(), 0);
+        return document;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void traverse(List<AbstractBlock> blocks, int indent) {
+        for (int i = 0; i < blocks.size(); i++) {
+            Object item = blocks.get(i);
+            if (item instanceof BlockImpl) {
+                BlockImpl block = (BlockImpl) item;
+                documentBuilder.addParagraph();
+                processParagraph(block.convert().trim());
+            } else if (item instanceof SectionImpl) {
+                SectionImpl section = (SectionImpl) item;
+                List<Sentence> headers = new ArrayList<>();
+                headers.add(new Sentence(section.title() != null ? section.title() : "", 0));
+                documentBuilder.appendSection(new Section(section.number(), headers));
+                traverse(section.blocks(), indent + 1);
+            } else if (item != null) {
+                AbstractBlock block = (AbstractBlock) item;
+                traverse(block.blocks(), indent + 1);
+            } else {
+                LOG.error("Unhandled AsciiDoctor Block class " + item.getClass().getSimpleName());
+            }
+        }
+    }
+
+    private void processParagraph(String paragraph) {
+        String sentenceText = "";
+        int offset = 0;
+        String[] sublines = paragraph.split("\001");
+        for (String subline : sublines) {
+            int lineNumberEndPos = subline.indexOf('\002');
+            if (lineNumberEndPos != -1) {
+                try {
+                    lineNumber = Integer.valueOf(subline.substring(0, lineNumberEndPos));
+                } catch (Exception e) {
+                    LOG.error("Error when parsing line number from converted AsciiDoc", e);
+                }
+                subline = subline.substring(lineNumberEndPos + 1);
+            }
+            subline = StringEscapeUtils.unescapeHtml4(subline);
+
+            sentenceText += subline;
+
+            while (true) {
+                int periodPosition = sentenceExtractor.getSentenceEndPosition(sentenceText);
+                if (periodPosition != -1) {
+                    String completeSentence = sentenceText.substring(0, periodPosition + 1);
+                    LineOffset lineOffset = addSentence(completeSentence, lineNumber, offset);
+                    lineNumber = lineOffset.lineNum;
+                    offset = lineOffset.offset;
+                    sentenceText = sentenceText.substring(periodPosition + 1);
+                } else {
+                    break;
+                }
+            }
+            lineNumber++;
+        }
+
+        if (!sentenceText.trim().isEmpty()) {
+            addSentence(sentenceText, lineNumber, offset);
+        }
+    }
+
+    public LineOffset addSentence(String rawSentenceText, int lineNumber, int offset) {
+        List<LineOffset> offsetMap = new ArrayList<>();
+        String normalizedSentence = "";
+        for (int i = 0; i < rawSentenceText.length(); i++) {
+            char ch = rawSentenceText.charAt(i);
+            if (ch == '\n') {
+                if (!sentenceExtractor.getBrokenLineSeparator().isEmpty()) {
+                    offsetMap.add(new LineOffset(lineNumber, offset));
+                    normalizedSentence += sentenceExtractor.getBrokenLineSeparator();
+                }
+                lineNumber++;
+                offset = 0;
+            } else {
+                normalizedSentence += ch;
+                offsetMap.add(new LineOffset(lineNumber, offset));
+                offset++;
+            }
+        }
+        Sentence sentence = new Sentence(normalizedSentence, lineNumber, offset);
+        sentence.setOffsetMap(offsetMap);
+        documentBuilder.addSentence(sentence);
+
+        return new LineOffset(lineNumber, offset);
+    }
+
+}

--- a/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
@@ -50,138 +50,45 @@ public class AsciiDocParserTest {
 
     @Test
     public void testBasicDocument() throws UnsupportedEncodingException, RedPenException {
-        String sampleText = "The Article Title\n" +
-                "=================\n" +
-                "Author's Name <authors@email.address>\n" +
-                "v1.0, 2003-12\n" +
-                "\n" +
-                "\n" +
-                "This is the optional preamble (an untitled section body). Useful for\n" +
-                "writing simple sectionless documents consisting only of a preamble.\n" +
-                "\n" +
-                "NOTE: The abstract, preface, appendix, bibliography, glossary and\n" +
-                "index section titles are significant ('specialsections').\n" +
-                "\n" +
-                "\n" +
-                ":numbered!:\n" +
-                "[abstract]\n" +
-                "Example Abstract\n" +
-                "----------------\n" +
-                "The optional abstract (one or more paragraphs) goes here.\n" +
-                "\n" +
-                "This document is an AsciiDoc article skeleton containing briefly\n" +
-                "annotated element placeholders plus a couple of example index entries\n" +
-                "and footnotes.\n" +
-                "\n" +
-                "This is a new paragraph that consists of this line. And also of this line.\nWith this, it would be three lines in total.\nBut this line spoils that and makes it four.\n" +
-                "\n" +
-                ":numbered:\n" +
-                "\n" +
-                "The First Section\n" +
-                "-----------------\n" +
-                "Article sections start at level 1 & can be nested up to four levels\n" +
-                "deep. Note that < and > are encoded by AsciiDoctor.\n" +
-                "footnote:[An example footnote.]\n" +
-                "indexterm:[Example index entry]\n" +
-                "\n" +
-                "And now for something completely different: ((monkeys)), lions and\n" +
-                "tigers (Bengal and Siberian) using the alternative syntax index\n" +
-                "entries.\n" +
-                "(((Big cats,Lions)))\n" +
-                "(((Big cats,Tigers,Bengal Tiger)))\n" +
-                "(((Big cats,Tigers,Siberian Tiger)))\n" +
-                "Note that multi-entry terms generate separate index entries.\n" +
-                "\n" +
-                "Here are a couple of image examples: an image:images/smallnew.png[]\n" +
-                "example inline image followed by an example block image:\n" +
-                "\n" +
-                ".Tiger block image\n" +
-                "image::images/tiger.png[Tiger image]\n" +
-                "\n" +
-                "Followed by an example table:\n" +
-                "\n" +
-                ".An example table\n" +
+        String sampleText = "Instances Overview\n==================\n" + "Author's Name <person@email.address>\nv1.2, 2015-08\n" +
+                "\nThis is the optional preamble (an untitled section body). Useful for " +
+                "writing simple sectionless documents consisting only of a preamble.\n\n" +
+                "NOTE: The abstract, preface, appendix, bibliography, glossary and index section titles are significant ('specialsections').\n" +
+                "\n\n:numbered!:\n[abstract]\n" +
+                "Instances\n" +
+                "---------\n" +
+                "In this article, we'll call a computer server that works as a member of a cluster an _instan3ce_. " +
+                "for example, as shown in this http://redpen.ignored.url/[mishpelled link], each instance in distributed search engines stores the the fractions of data.\n" +
+                "\nSuch distriubuted systems need a component to merge the preliminary results from member instnaces.\n\n\n" +
+                ".Instance image\n" +
+                "image::images/tiger.png[Instance image]\n\n" +
+                "A sample table:\n\n" +
+                ".A sample table\n" +
                 "[width=\"60%\",options=\"header\"]\n" +
                 "|==============================================\n" +
-                "| Option          | Description\n" +
-                "| -a 'USER GROUP' | Add 'USER' to 'GROUP'.\n" +
-                "| -R 'GROUP'      | Disables access to 'GROUP'.\n" +
-                "|==============================================\n" +
-                "\n" +
-                ".An example example\n" +
+                "| Option     | Description\n" +
+                "| GROUP      | The instance group.\n" +
+                "|==============================================\n\n" +
+                ".example list\n" +
                 "===============================================\n" +
                 "Lorum ipum...\n" +
-                "===============================================\n" +
-                "\n" +
-                "[[X1]]\n" +
-                "Sub-section with Anchor\n" +
-                "~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                "Sub-section at level 2.\n" +
-                "\n" +
-                "A Nested Sub-section\n" +
-                "^^^^^^^^^^^^^^^^^^^^\n" +
-                "Sub-section at level 3.\n" +
-                "\n" +
-                "Yet another nested Sub-section\n" +
-                "++++++++++++++++++++++++++++++\n" +
-                "Sub-section at level 4.\n" +
-                "\n" +
-                "This is the maximum sub-section depth supported by the distributed\n" +
-                "AsciiDoc configuration.\n" +
-                "footnote:[A second example footnote.]\n" +
-                "\n" +
-                "\n" +
-                "二 セクション\n" +
-                "-------\n" +
-                "Article sections are at level 1 and can contain sub-sections nested up\n" +
-                "to four deep.\n" +
-                "\n" +
-                "An example link to anchor at start of the <<X1,first sub-section>>.\n" +
-                "indexterm:[Second example index entry]\n" +
-                "\n" +
-                "An example link to a bibliography entry <<taoup>>.\n" +
-                "\n" +
-                "\n" +
-                ":numbered!:\n" +
-                "\n" +
-                "[appendix]\n" +
-                "Example Appendix\n" +
-                "----------------\n" +
-                "AsciiDoc article appendices are just just article sections with\n" +
-                "'specialsection' titles.\n" +
-                "\n" +
-                "Appendix Sub-section\n" +
-                "~~~~~~~~~~~~~~~~~~~~\n" +
-                "Appendix sub-section at level 2.\n" +
-                "\n" +
-                "\n" +
-                "[bibliography]\n" +
-                "Example Bibliography\n" +
-                "--------------------\n" +
-                "The bibliography list is a style of AsciiDoc bulleted list.\n" +
-                "\n" +
+                "===============================================\n\n\n" +
                 "[bibliography]\n" +
                 "- [[[taoup]]] Eric Steven Raymond. 'The Art of Unix\n" +
                 "  Programming'. Addison-Wesley. ISBN 0-13-142901-9.\n" +
                 "- [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.\n" +
                 "  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999.\n" +
-                "  ISBN 1-56592-580-7.\n" +
-                "\n" +
-                "\n" +
+                "  ISBN 1-56592-580-7.\n\n\n" +
                 "[glossary]\n" +
                 "Example Glossary\n" +
                 "----------------\n" +
                 "Glossaries are optional. Glossaries entries are an example of a style\n" +
-                "of AsciiDoc labeled lists.\n" +
-                "\n" +
+                "of AsciiDoc labeled lists.\n\n" +
                 "[glossary]\n" +
                 "A glossary term::\n" +
-                "  The corresponding (indented) definition.\n" +
-                "\n" +
+                "  The corresponding (indented) definition.\n\n" +
                 "A second glossary term::\n" +
-                "  The corresponding (indented) definition.\n" +
-                "\n" +
-                "\n" +
+                "  The corresponding (indented) definition.\n\n\n" +
                 "ifdef::backend-docbook[]\n" +
                 "[index]\n" +
                 "Example Index\n" +
@@ -192,31 +99,13 @@ public class AsciiDocParserTest {
                 "////////////////////////////////////////////////////////////////\n" +
                 "endif::backend-docbook[]";
 
+
         Document doc = createFileContent(sampleText);
-
-        assertNotNull("doc is null", doc);
-        assertEquals(11, doc.size());
-
-        final Section firstSection = doc.getSection(0);
-        assertEquals(1, firstSection.getHeaderContentsListSize());
-        assertEquals("The Article Title", firstSection.getHeaderContent(0).getContent());
-        assertEquals(0, firstSection.getNumberOfLists());
-        assertEquals(1, firstSection.getNumberOfParagraphs());
-        assertEquals(0, firstSection.getNumberOfSubsections());
-
-        Configuration configuration = new Configuration.ConfigurationBuilder()
-                .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
-                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol")).build();
-
-        RedPen redPen = new RedPen(configuration);
-        List<ValidationError> errors = redPen.validate(doc);
-        for (ValidationError error : errors) {
-            System.out.println(error.getMessage());
-        }
 
         for (Section section : doc) {
             for (Paragraph paragraph : section.getParagraphs()) {
                 paragraph.getSentences().forEach(sentence -> assertNotNull(sentence.getContent()));
+                //     paragraph.getSentences().forEach(sentence -> dumpSentence(sentence));
                 section.getHeaderContents().forEach(sentence -> assertNotNull(sentence.getContent()));
                 for (ListBlock listBlock : section.getListBlocks()) {
                     for (ListElement listElement : listBlock.getListElements()) {
@@ -225,6 +114,34 @@ public class AsciiDocParserTest {
                 }
             }
         }
+
+        assertNotNull("doc is null", doc);
+        assertEquals(3, doc.size());
+
+        final Section firstSection = doc.getSection(0);
+        assertEquals(1, firstSection.getHeaderContentsListSize());
+        assertEquals("Instances Overview", firstSection.getHeaderContent(0).getContent());
+        assertEquals(0, firstSection.getNumberOfLists());
+        assertEquals(1, firstSection.getNumberOfParagraphs());
+        assertEquals(0, firstSection.getNumberOfSubsections());
+
+        Configuration configuration = new Configuration.ConfigurationBuilder()
+                .addValidatorConfig(new ValidatorConfiguration("Spelling"))
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol")).build();
+
+        RedPen redPen = new RedPen(configuration);
+        List<ValidationError> errors = redPen.validate(doc);
+        for (ValidationError error : errors) {
+            System.out.println(error.getMessage());
+        }
+    }
+
+    private void dumpSentence(Sentence sentence) {
+        for (int i = 0; i < sentence.getContent().length(); i++) {
+            String offset = sentence.getOffset(i).isPresent() ? sentence.getOffset(i).get().lineNum + "," + sentence.getOffset(i).get().offset : "n/a";
+            System.out.print("[" + sentence.getContent().charAt(i) + ":" + offset + "]");
+        }
+        System.out.println();
     }
 
     private Document createFileContent(String inputDocumentString,
@@ -244,7 +161,9 @@ public class AsciiDocParserTest {
         Document doc = null;
         try {
             Configuration configuration = new Configuration.ConfigurationBuilder().build();
-            doc = parser.parse(inputDocumentString, new SentenceExtractor(configuration.getSymbolTable()),
+            doc = parser.parse(
+                    inputDocumentString,
+                    new SentenceExtractor(configuration.getSymbolTable()),
                     configuration.getTokenizer());
         } catch (RedPenException e) {
             e.printStackTrace();

--- a/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
@@ -1,0 +1,310 @@
+/**
+ * redpen: a text inspection tool
+ * Copyright (c) 2014-2015 Recruit Technologies Co., Ltd. and contributors
+ * (see CONTRIBUTORS.md)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cc.redpen;
+
+import cc.redpen.config.Configuration;
+import cc.redpen.model.*;
+import cc.redpen.parser.DocumentParser;
+import cc.redpen.parser.LineOffset;
+import cc.redpen.parser.SentenceExtractor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class AsciiDocParserTest {
+
+    @Before
+    public void setup() {
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullDocument() throws Exception {
+        Configuration configuration = new Configuration.ConfigurationBuilder().build();
+        DocumentParser parser = DocumentParser.ASCIIDOC;
+        InputStream is = null;
+        parser.parse(is, new SentenceExtractor(configuration.getSymbolTable()), configuration.getTokenizer());
+    }
+
+    @Test
+    public void testBasicDocument() throws UnsupportedEncodingException, RedPenException {
+        String sampleText = "The Article Title\n" +
+                "=================\n" +
+                "Author's Name <authors@email.address>\n" +
+                "v1.0, 2003-12\n" +
+                "\n" +
+                "\n" +
+                "This is the optional preamble (an untitled section body). Useful for\n" +
+                "writing simple sectionless documents consisting only of a preamble.\n" +
+                "\n" +
+                "NOTE: The abstract, preface, appendix, bibliography, glossary and\n" +
+                "index section titles are significant ('specialsections').\n" +
+                "\n" +
+                "\n" +
+                ":numbered!:\n" +
+                "[abstract]\n" +
+                "Example Abstract\n" +
+                "----------------\n" +
+                "The optional abstract (one or more paragraphs) goes here.\n" +
+                "\n" +
+                "This document is an AsciiDoc article skeleton containing briefly\n" +
+                "annotated element placeholders plus a couple of example index entries\n" +
+                "and footnotes.\n" +
+                "\n" +
+                "This is a new paragraph that consists of this line. And also of this line.\nWith this, it would be three lines in total.\nBut this line spoils that and makes it four.\n" +
+                "\n" +
+                ":numbered:\n" +
+                "\n" +
+                "The First Section\n" +
+                "-----------------\n" +
+                "Article sections start at level 1 & can be nested up to four levels\n" +
+                "deep. Note that < and > are encoded by AsciiDoctor.\n" +
+                "footnote:[An example footnote.]\n" +
+                "indexterm:[Example index entry]\n" +
+                "\n" +
+                "And now for something completely different: ((monkeys)), lions and\n" +
+                "tigers (Bengal and Siberian) using the alternative syntax index\n" +
+                "entries.\n" +
+                "(((Big cats,Lions)))\n" +
+                "(((Big cats,Tigers,Bengal Tiger)))\n" +
+                "(((Big cats,Tigers,Siberian Tiger)))\n" +
+                "Note that multi-entry terms generate separate index entries.\n" +
+                "\n" +
+                "Here are a couple of image examples: an image:images/smallnew.png[]\n" +
+                "example inline image followed by an example block image:\n" +
+                "\n" +
+                ".Tiger block image\n" +
+                "image::images/tiger.png[Tiger image]\n" +
+                "\n" +
+                "Followed by an example table:\n" +
+                "\n" +
+                ".An example table\n" +
+                "[width=\"60%\",options=\"header\"]\n" +
+                "|==============================================\n" +
+                "| Option          | Description\n" +
+                "| -a 'USER GROUP' | Add 'USER' to 'GROUP'.\n" +
+                "| -R 'GROUP'      | Disables access to 'GROUP'.\n" +
+                "|==============================================\n" +
+                "\n" +
+                ".An example example\n" +
+                "===============================================\n" +
+                "Lorum ipum...\n" +
+                "===============================================\n" +
+                "\n" +
+                "[[X1]]\n" +
+                "Sub-section with Anchor\n" +
+                "~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "Sub-section at level 2.\n" +
+                "\n" +
+                "A Nested Sub-section\n" +
+                "^^^^^^^^^^^^^^^^^^^^\n" +
+                "Sub-section at level 3.\n" +
+                "\n" +
+                "Yet another nested Sub-section\n" +
+                "++++++++++++++++++++++++++++++\n" +
+                "Sub-section at level 4.\n" +
+                "\n" +
+                "This is the maximum sub-section depth supported by the distributed\n" +
+                "AsciiDoc configuration.\n" +
+                "footnote:[A second example footnote.]\n" +
+                "\n" +
+                "\n" +
+                "二 セクション\n" +
+                "-------\n" +
+                "Article sections are at level 1 and can contain sub-sections nested up\n" +
+                "to four deep.\n" +
+                "\n" +
+                "An example link to anchor at start of the <<X1,first sub-section>>.\n" +
+                "indexterm:[Second example index entry]\n" +
+                "\n" +
+                "An example link to a bibliography entry <<taoup>>.\n" +
+                "\n" +
+                "\n" +
+                ":numbered!:\n" +
+                "\n" +
+                "[appendix]\n" +
+                "Example Appendix\n" +
+                "----------------\n" +
+                "AsciiDoc article appendices are just just article sections with\n" +
+                "'specialsection' titles.\n" +
+                "\n" +
+                "Appendix Sub-section\n" +
+                "~~~~~~~~~~~~~~~~~~~~\n" +
+                "Appendix sub-section at level 2.\n" +
+                "\n" +
+                "\n" +
+                "[bibliography]\n" +
+                "Example Bibliography\n" +
+                "--------------------\n" +
+                "The bibliography list is a style of AsciiDoc bulleted list.\n" +
+                "\n" +
+                "[bibliography]\n" +
+                "- [[[taoup]]] Eric Steven Raymond. 'The Art of Unix\n" +
+                "  Programming'. Addison-Wesley. ISBN 0-13-142901-9.\n" +
+                "- [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.\n" +
+                "  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999.\n" +
+                "  ISBN 1-56592-580-7.\n" +
+                "\n" +
+                "\n" +
+                "[glossary]\n" +
+                "Example Glossary\n" +
+                "----------------\n" +
+                "Glossaries are optional. Glossaries entries are an example of a style\n" +
+                "of AsciiDoc labeled lists.\n" +
+                "\n" +
+                "[glossary]\n" +
+                "A glossary term::\n" +
+                "  The corresponding (indented) definition.\n" +
+                "\n" +
+                "A second glossary term::\n" +
+                "  The corresponding (indented) definition.\n" +
+                "\n" +
+                "\n" +
+                "ifdef::backend-docbook[]\n" +
+                "[index]\n" +
+                "Example Index\n" +
+                "-------------\n" +
+                "////////////////////////////////////////////////////////////////\n" +
+                "The index is normally left completely empty, it's contents being\n" +
+                "generated automatically by the DocBook toolchain.\n" +
+                "////////////////////////////////////////////////////////////////\n" +
+                "endif::backend-docbook[]";
+
+        sampleText  = "Instances Overview\n====================\nAuthor's Name <person@email.address>\nv1.2, 2015-08\n" +
+                "\nThis is the optional preamble (an untitled section body). Useful for\n" +
+                "writing simple sectionless documents consisting only of a preamble.\n\n" +
+                "NOTE: The abstract, preface, appendix, bibliography, glossary and\nindex section titles are significant ('specialsections').\n" +
+                "\n\n:numbered!:\n[abstract]\n" +
+                "Instances\n" +
+                "---------\n" +
+                "In this article, we'll call a computer server that works as a member of a cluster an _instance_. for example, each instance in distributed search engines stores the the fractions of data.\n" +
+                "\n Such distriubuted systems need a component to merge the preliminary results from member instnaces.\n\n\n" +
+                ".Instance image\n" +
+                "image::images/tiger.png[Instance image]\n\n" +
+                "A sample table:\n\n" +
+                ".A sample table\n" +
+                "[width=\"60%\",options=\"header\"]\n" +
+                "|==============================================\n" +
+                "| Option     | Description\n" +
+                "| NAME       | The name of the instance\n" +
+                "| GROUP      | The instance group.\n" +
+                "|==============================================\n\n" +
+                ".example list\n" +
+                "===============================================\n" +
+                "Lorum ipum...\n" +
+                "===============================================\n\n\n" +
+                "[bibliography]\n" +
+                "- [[[taoup]]] Eric Steven Raymond. 'The Art of Unix\n" +
+                "  Programming'. Addison-Wesley. ISBN 0-13-142901-9.\n" +
+                "- [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.\n" +
+                "  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999.\n" +
+                "  ISBN 1-56592-580-7.\n\n\n" +
+                "[glossary]\n" +
+                "Example Glossary\n" +
+                "----------------\n" +
+                "Glossaries are optional. Glossaries entries are an example of a style\n" +
+                "of AsciiDoc labeled lists.\n\n" +
+                "[glossary]\n" +
+                "A glossary term::\n" +
+                "  The corresponding (indented) definition.\n\n" +
+                "A second glossary term::\n" +
+                "  The corresponding (indented) definition.\n\n\n" +
+                "ifdef::backend-docbook[]\n" +
+                "[index]\n" +
+                "Example Index\n" +
+                "-------------\n" +
+                "////////////////////////////////////////////////////////////////\n" +
+                "The index is normally left completely empty, it's contents being\n" +
+                "generated automatically by the DocBook toolchain.\n" +
+                "////////////////////////////////////////////////////////////////\n" +
+                "endif::backend-docbook[]";
+
+        Document doc = createFileContent(sampleText);
+
+        assertNotNull("doc is null", doc);
+//        assertEquals(11, doc.size());
+
+//        final Section firstSection = doc.getSection(0);
+//        assertEquals(2, firstSection.getHeaderContentsListSize());
+//        assertEquals("", firstSection.getHeaderContent(0).getContent());
+//        assertEquals(0, firstSection.getNumberOfLists());
+//        assertEquals(1, firstSection.getNumberOfParagraphs());
+//        assertEquals(0, firstSection.getNumberOfSubsections());
+//
+//        Configuration configuration = new Configuration.ConfigurationBuilder()
+//                .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
+//                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol")).build();
+//
+//        RedPen redPen = new RedPen(configuration);
+//        List<ValidationError> errors = redPen.validate(doc);
+//        for (ValidationError error : errors) {
+//            System.out.println(error.getMessage());
+//        }
+
+        for (Section section : doc) {
+            for (Paragraph paragraph : section.getParagraphs()) {
+                paragraph.getSentences().forEach(sentence -> assertNotNull(sentence.getContent()));
+                section.getHeaderContents().forEach(sentence -> assertNotNull(sentence.getContent()));
+                for (ListBlock listBlock : section.getListBlocks()) {
+                    for (ListElement listElement : listBlock.getListElements()) {
+                        listElement.getSentences().forEach(sentence -> assertNotNull(sentence.getContent()));
+                    }
+                }
+            }
+        }
+    }
+
+    private Document createFileContent(String inputDocumentString,
+                                       Configuration config) {
+        DocumentParser parser = DocumentParser.ASCIIDOC;
+
+        try {
+            return parser.parse(inputDocumentString, new SentenceExtractor(config.getSymbolTable()), config.getTokenizer());
+        } catch (RedPenException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private Document createFileContent(String inputDocumentString) {
+        DocumentParser parser = DocumentParser.ASCIIDOC;
+        Document doc = null;
+        try {
+            Configuration configuration = new Configuration.ConfigurationBuilder().build();
+            doc = parser.parse(inputDocumentString, new SentenceExtractor(configuration.getSymbolTable()),
+                    configuration.getTokenizer());
+        } catch (RedPenException e) {
+            e.printStackTrace();
+            fail();
+        }
+        return doc;
+    }
+
+    private static List<LineOffset> initializeMappingTable(LineOffset... offsets) {
+        List<LineOffset> offsetTable = new ArrayList<>();
+        for (LineOffset offset : offsets) {
+            offsetTable.add(offset);
+        }
+        return offsetTable;
+    }
+}

--- a/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/AsciiDocParserTest.java
@@ -18,10 +18,12 @@
 package cc.redpen;
 
 import cc.redpen.config.Configuration;
+import cc.redpen.config.ValidatorConfiguration;
 import cc.redpen.model.*;
 import cc.redpen.parser.DocumentParser;
 import cc.redpen.parser.LineOffset;
 import cc.redpen.parser.SentenceExtractor;
+import cc.redpen.validator.ValidationError;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -190,76 +192,27 @@ public class AsciiDocParserTest {
                 "////////////////////////////////////////////////////////////////\n" +
                 "endif::backend-docbook[]";
 
-        sampleText  = "Instances Overview\n====================\nAuthor's Name <person@email.address>\nv1.2, 2015-08\n" +
-                "\nThis is the optional preamble (an untitled section body). Useful for\n" +
-                "writing simple sectionless documents consisting only of a preamble.\n\n" +
-                "NOTE: The abstract, preface, appendix, bibliography, glossary and\nindex section titles are significant ('specialsections').\n" +
-                "\n\n:numbered!:\n[abstract]\n" +
-                "Instances\n" +
-                "---------\n" +
-                "In this article, we'll call a computer server that works as a member of a cluster an _instance_. for example, each instance in distributed search engines stores the the fractions of data.\n" +
-                "\n Such distriubuted systems need a component to merge the preliminary results from member instnaces.\n\n\n" +
-                ".Instance image\n" +
-                "image::images/tiger.png[Instance image]\n\n" +
-                "A sample table:\n\n" +
-                ".A sample table\n" +
-                "[width=\"60%\",options=\"header\"]\n" +
-                "|==============================================\n" +
-                "| Option     | Description\n" +
-                "| NAME       | The name of the instance\n" +
-                "| GROUP      | The instance group.\n" +
-                "|==============================================\n\n" +
-                ".example list\n" +
-                "===============================================\n" +
-                "Lorum ipum...\n" +
-                "===============================================\n\n\n" +
-                "[bibliography]\n" +
-                "- [[[taoup]]] Eric Steven Raymond. 'The Art of Unix\n" +
-                "  Programming'. Addison-Wesley. ISBN 0-13-142901-9.\n" +
-                "- [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.\n" +
-                "  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999.\n" +
-                "  ISBN 1-56592-580-7.\n\n\n" +
-                "[glossary]\n" +
-                "Example Glossary\n" +
-                "----------------\n" +
-                "Glossaries are optional. Glossaries entries are an example of a style\n" +
-                "of AsciiDoc labeled lists.\n\n" +
-                "[glossary]\n" +
-                "A glossary term::\n" +
-                "  The corresponding (indented) definition.\n\n" +
-                "A second glossary term::\n" +
-                "  The corresponding (indented) definition.\n\n\n" +
-                "ifdef::backend-docbook[]\n" +
-                "[index]\n" +
-                "Example Index\n" +
-                "-------------\n" +
-                "////////////////////////////////////////////////////////////////\n" +
-                "The index is normally left completely empty, it's contents being\n" +
-                "generated automatically by the DocBook toolchain.\n" +
-                "////////////////////////////////////////////////////////////////\n" +
-                "endif::backend-docbook[]";
-
         Document doc = createFileContent(sampleText);
 
         assertNotNull("doc is null", doc);
-//        assertEquals(11, doc.size());
+        assertEquals(11, doc.size());
 
-//        final Section firstSection = doc.getSection(0);
-//        assertEquals(2, firstSection.getHeaderContentsListSize());
-//        assertEquals("", firstSection.getHeaderContent(0).getContent());
-//        assertEquals(0, firstSection.getNumberOfLists());
-//        assertEquals(1, firstSection.getNumberOfParagraphs());
-//        assertEquals(0, firstSection.getNumberOfSubsections());
-//
-//        Configuration configuration = new Configuration.ConfigurationBuilder()
-//                .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
-//                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol")).build();
-//
-//        RedPen redPen = new RedPen(configuration);
-//        List<ValidationError> errors = redPen.validate(doc);
-//        for (ValidationError error : errors) {
-//            System.out.println(error.getMessage());
-//        }
+        final Section firstSection = doc.getSection(0);
+        assertEquals(1, firstSection.getHeaderContentsListSize());
+        assertEquals("The Article Title", firstSection.getHeaderContent(0).getContent());
+        assertEquals(0, firstSection.getNumberOfLists());
+        assertEquals(1, firstSection.getNumberOfParagraphs());
+        assertEquals(0, firstSection.getNumberOfSubsections());
+
+        Configuration configuration = new Configuration.ConfigurationBuilder()
+                .addValidatorConfig(new ValidatorConfiguration("SentenceLength"))
+                .addValidatorConfig(new ValidatorConfiguration("InvalidSymbol")).build();
+
+        RedPen redPen = new RedPen(configuration);
+        List<ValidationError> errors = redPen.validate(doc);
+        for (ValidationError error : errors) {
+            System.out.println(error.getMessage());
+        }
 
         for (Section section : doc) {
             for (Paragraph paragraph : section.getParagraphs()) {

--- a/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
+++ b/redpen-core/src/test/java/cc/redpen/PlainTextParserTest.java
@@ -278,6 +278,22 @@ public class PlainTextParserTest {
     }
 
     @Test
+    public void testPlainTextOffsets() {
+        String sampleText = "ラ、、になる。ラ、、\nになる。ラ、、になる。";
+        Document doc = generateDocument(sampleText, "ja");
+        Section section = doc.getLastSection();
+        List<Paragraph> paragraphs = extractParagraphs(section);
+        assertEquals(1, paragraphs.size());
+        assertEquals(3, getTotalSentenceCount(section));
+        Paragraph paragraph1 = paragraphs.get(0);
+
+        assertEquals(3, paragraph1.getNumberOfSentences());
+
+        assertEquals(7, paragraph1.getSentence(1).getStartPositionOffset());
+        assertEquals(1, paragraph1.getSentence(1).getLineNumber());
+    }
+
+    @Test
     public void testPlainTextReverseOffsets() {
         String sampleText = "お祖母さんの鉛筆は田の\n中にあります。お祖母さんの鉛筆が中にあるの\n田はどこですか？私の家\nの後ろあります";
         Document doc = generateDocument(sampleText, "ja");
@@ -328,7 +344,6 @@ public class PlainTextParserTest {
         assertEquals(1, errors.size());
         assertEquals("InvalidSymbol", errors.get(0).getValidatorName());
         assertEquals(19, errors.get(0).getSentence().getContent().length());
-        // plain text parser does not support error position.
         assertEquals(Optional.of(new LineOffset(1, 18)), errors.get(0).getStartPosition());
         assertEquals(Optional.of(new LineOffset(1, 19)), errors.get(0).getEndPosition());
     }

--- a/redpen-server/src/main/webapp/css/redpen.css
+++ b/redpen-server/src/main/webapp/css/redpen.css
@@ -185,7 +185,9 @@ input[type="radio"], input[type="checkbox"] {
     margin: 0 !important;
     word-wrap: normal;
     white-space: pre-wrap;
-    font-size: 19px;
+    font-size: 17px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
     border: none !important;
     outline: none !important;
     z-index: 2;
@@ -212,7 +214,9 @@ input[type="radio"], input[type="checkbox"] {
     margin: 0 !important;
     word-wrap: normal;
     white-space: pre-wrap;
-    font-size: 19px;
+    font-size: 17px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
     background-color: #fff;
     color: transparent;
     width: 100%;
@@ -434,7 +438,7 @@ input[type="radio"], input[type="checkbox"] {
 .redpen-symboltable {
     font-size: 11px;
     width: 100%;
-    text-align:right;
+    text-align: right;
 }
 
 .redpen-symboltable th {
@@ -445,7 +449,7 @@ input[type="radio"], input[type="checkbox"] {
     min-width: 32px;
 }
 
-.redpen-symboltable th:first-child,.redpen-symboltable td:first-child  {
+.redpen-symboltable th:first-child, .redpen-symboltable td:first-child {
     text-align: left;
 }
 
@@ -499,6 +503,7 @@ input[type="radio"], input[type="checkbox"] {
     text-shadow: 0 0 2px rgba(255, 32, 0, 0.4);
     font-style: normal;
     background-image: url(../images/redpen-mark.png);
+    background-size: 48px 19px;
 }
 
 .redpen-annotated-sentence-marker {

--- a/redpen-server/src/main/webapp/css/redpen.css
+++ b/redpen-server/src/main/webapp/css/redpen.css
@@ -171,57 +171,45 @@ input[type="radio"], input[type="checkbox"] {
     background-color: white;
 }
 
-#redpen-editor {
+.redpen-superimposed-editor-panel {
     border-radius: 6px;
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
-    color: rgba(0, 0, 0, 0.7);
-    background-color: transparent;
-    line-height: 28px;
-    padding: 24px !important;
+    line-height: 28px !important;
+    padding: 12px !important;
     margin: 0 !important;
-    word-wrap: normal;
-    white-space: pre-wrap;
-    font-size: 17px;
-    font-weight: bold;
-    font-family: "Courier New", monospace;
+    word-wrap: normal !important;
+    white-space: pre-wrap !important;
+    word-break: normal !important;
+    font-size: 14px !important;
+    font-weight: normal !important;
+    font-family: monospace !important;
+
+    width: 100%;
+
     border: none !important;
     outline: none !important;
-    z-index: 2;
-    height: 100%;
-    width: 100%;
+    overflow-y: scroll;
+    overflow-x: hidden;
+
     -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
     -moz-box-sizing: border-box; /* Firefox, other Gecko */
     box-sizing: border-box;
-    overflow-y: scroll;
+}
+
+#redpen-editor {
+    color: rgba(0, 0, 0, 0.9);
+    background-color: transparent;
+    height: 100%;
+    z-index: 2;
 }
 
 #redpen-editor-underlay {
-    border-radius: 6px;
-    overflow-y: scroll;
-
-    position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-
-    line-height: 28px;
-    padding: 24px !important;
-    margin: 0 !important;
-    word-wrap: normal;
-    white-space: pre-wrap;
-    font-size: 17px;
-    font-weight: bold;
-    font-family: "Courier New", monospace;
-    background-color: #fff;
+    background-color: rgba(220, 255, 220, 0.4);
     color: transparent;
-    width: 100%;
-    border: none !important;
-    outline: none !important;
     z-index: 1;
 }
 
@@ -361,9 +349,10 @@ input[type="radio"], input[type="checkbox"] {
 
 .redpen-clear-button {
     position: absolute;
-    bottom: 2px;
-    right: 10px;
+    bottom: 3px;
+    right: 18px;
     z-index: 3;
+    color: #777;
 }
 
 .redpen-clear-button button {
@@ -503,7 +492,7 @@ input[type="radio"], input[type="checkbox"] {
     text-shadow: 0 0 2px rgba(255, 32, 0, 0.4);
     font-style: normal;
     background-image: url(../images/redpen-mark.png);
-    background-size: 48px 19px;
+    background-size: 48px 16px;
 }
 
 .redpen-annotated-sentence-marker {
@@ -513,15 +502,15 @@ input[type="radio"], input[type="checkbox"] {
     background-color: transparent;
     color: rgba(167, 12, 0, 0.90);
     text-shadow: 0 0 1px rgba(0, 0, 0, 0.31);
-    font-size: 9px;
+    font-size: 8px;
     display: inline-block;
     vertical-align: top;
     text-align: right;
-    margin-left: -24px;
+    margin-left: -18px;
     margin-top: -10px;
-    height: 20px;
-    width: 24px;
-    z-index: 2;
+    height: 10px;
+    width: 18px;
+    z-index: 3;
 }
 
 ::-webkit-scrollbar-track {

--- a/redpen-server/src/main/webapp/index.html
+++ b/redpen-server/src/main/webapp/index.html
@@ -58,15 +58,59 @@ var sampleDocuments = {
             "本稿では,複数の計算機（クラスタ）でで動作する各サーバーを_「インスタンス」_と呼びまます。\n" +
             "たとえば検索エンジンやデータベースではインデックスを複数のインスタンスで分割して保持します。\n" +
             "このような場合、各インデクスの結果をマージして_clientプログラム_に渡す機構が必要となります。"},
-    en_ad: {parser: "ASCIIDOC", document: "= Instances\n" +
-            "Some software tools work in more than one machine, and such _distributed_ (cluster)systems can handle huge data or tasks, because such software tools make use of large amount of computer resources, such as\n" +
-            "* CPU\n* Disk\n* Memory\n\n" +
-            "In this article, we'll call a computer server that works as a member of a cluster an _instance_. for example, each instance in distributed search engines stores the the fractions of data." +
-            " Such distriubuted systems need a component to merge the preliminary results from member instnaces."},
-    ja_ad: {parser: "ASCIIDOC", document: "= 分散処理\n最近利用されているソフトウェアの中には複数の計算機上で動作（分散）するものが多く存在し、このような分散ソフトウェアは複数の計算機で動作することで大量のデータを扱えたり，高負荷な状況に対処できたりします。\n" +
-            "本稿では,複数の計算機（クラスタ）でで動作する各サーバーを_「インスタンス」_と呼びまます。\n" +
+    en_ad: {parser: "ASCIIDOC", document: "Instances Overview\n==================\nAuthor's Name <person@email.address>\nv1.2, 2015-08\n" +
+            "\nThis is the optional preamble (an untitled section body). Useful for\n" +
+            "writing simple sectionless documents consisting only of a preamble.\n\n" +
+            "NOTE: The abstract, preface, appendix, bibliography, glossary and\nindex section titles are significant ('specialsections').\n" +
+            "\n\n:numbered!:\n[abstract]\n" +
+            "Instances\n" +
+            "---------\n" +
+            "In this article, we'll call a computer server that works as a member of a cluster an _instance_. for example, each instance in distributed search engines stores the the fractions of data.\n" +
+            "\n Such distriubuted systems need a component to merge the preliminary results from member instnaces.\n\n\n" +
+            ".Instance image\n" +
+            "image::images/tiger.png[Instance image]\n\n" +
+            "A sample table:\n\n" +
+            ".A sample table\n" +
+            "[width=\"60%\",options=\"header\"]\n" +
+            "|==============================================\n" +
+            "| Option     | Description\n" +
+            "| NAME       | The name of the instance\n" +
+            "| GROUP      | The instance group.\n" +
+            "|==============================================\n\n" +
+            ".example list\n" +
+            "===============================================\n" +
+            "Lorum ipum...\n" +
+            "===============================================\n\n\n" +
+            "[bibliography]\n" +
+            "- [[[taoup]]] Eric Steven Raymond. 'The Art of Unix\n" +
+            "  Programming'. Addison-Wesley. ISBN 0-13-142901-9.\n" +
+            "- [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.\n" +
+            "  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999.\n" +
+            "  ISBN 1-56592-580-7.\n\n\n" +
+            "[glossary]\n" +
+            "Example Glossary\n" +
+            "----------------\n" +
+            "Glossaries are optional. Glossaries entries are an example of a style\n" +
+            "of AsciiDoc labeled lists.\n\n" +
+            "[glossary]\n" +
+            "A glossary term::\n" +
+            "  The corresponding (indented) definition.\n\n" +
+            "A second glossary term::\n" +
+            "  The corresponding (indented) definition.\n\n\n" +
+            "ifdef::backend-docbook[]\n" +
+            "[index]\n" +
+            "Example Index\n" +
+            "-------------\n" +
+            "////////////////////////////////////////////////////////////////\n" +
+            "The index is normally left completely empty, it's contents being\n" +
+            "generated automatically by the DocBook toolchain.\n" +
+            "////////////////////////////////////////////////////////////////\n" +
+            "endif::backend-docbook[]"},
+    ja_ad: {parser: "ASCIIDOC", document: "[abstract]\n分散処理\n====\n\n最近利用されているソフトウェアの中には複数の計算機上で動作（分散）するものが多く存在し、このような分散ソフトウェアは複数の計算機で動作することで大量のデータを扱えたり，高負荷な状況に対処できたりします。\n" +
+            "本稿では,複数の計算機（クラスタ）でで動作する各サーバーを_「インスタンス」_と呼びまます。\n\n" +
             "たとえば検索エンジンやデータベースではインデックスを複数のインスタンスで分割して保持します。\n" +
             "このような場合、各インデクスの結果をマージして_clientプログラム_に渡す機構が必要となります。"}
+
 };
 
 // ensure the language autodetect doesn't override the user's selection
@@ -84,6 +128,7 @@ function pasteSampleText(key) {
         permitLanguageAutoDetect = true;
         text = sampleDocuments[key].document;
         $("#redpen-document-parser").val(sampleDocuments[key].parser);
+        $('#redpen-errors').empty();
     }
     $("#redpen-editor")
             .val(text ? text : "")
@@ -651,8 +696,8 @@ $(document).ready(function () {
                             <li><a onclick="pasteSampleText('ja')">Japanese Text</a></li>
                             <li><a onclick="pasteSampleText('en_md')">English Markdown</a></li>
                             <li><a onclick="pasteSampleText('ja_md')">Japanese Markdown</a></li>
-                            <!--<li><a onclick="pasteSampleText('en_ad')">English AsciiDoc</a></li>-->
-                            <!--<li><a onclick="pasteSampleText('ja_ad')">Japanese AsciiDoc</a></li>-->
+                            <li><a onclick="pasteSampleText('en_ad')">English AsciiDoc</a></li>
+                            <li><a onclick="pasteSampleText('ja_ad')">Japanese AsciiDoc</a></li>
                         </ul>
                     </li>
                     <li>

--- a/redpen-server/src/main/webapp/index.html
+++ b/redpen-server/src/main/webapp/index.html
@@ -58,15 +58,16 @@ var sampleDocuments = {
             "本稿では,複数の計算機（クラスタ）でで動作する各サーバーを_「インスタンス」_と呼びまます。\n" +
             "たとえば検索エンジンやデータベースではインデックスを複数のインスタンスで分割して保持します。\n" +
             "このような場合、各インデクスの結果をマージして_clientプログラム_に渡す機構が必要となります。"},
-    en_ad: {parser: "ASCIIDOC", document: "Instances Overview\n==================\nAuthor's Name <person@email.address>\nv1.2, 2015-08\n" +
-            "\nThis is the optional preamble (an untitled section body). Useful for\n" +
+    en_ad: {parser: "ASCIIDOC", document: "Instances Overview\n==================\n" + "Author's Name <person@email.address>\nv1.2, 2015-08\n" +
+            "\nThis is the optional preamble (an untitled section body). Useful for " +
             "writing simple sectionless documents consisting only of a preamble.\n\n" +
-            "NOTE: The abstract, preface, appendix, bibliography, glossary and\nindex section titles are significant ('specialsections').\n" +
+            "NOTE: The abstract, preface, appendix, bibliography, glossary and index section titles are significant ('specialsections').\n" +
             "\n\n:numbered!:\n[abstract]\n" +
             "Instances\n" +
             "---------\n" +
-            "In this article, we'll call a computer server that works as a member of a cluster an _instance_. for example, each instance in distributed search engines stores the the fractions of data.\n" +
-            "\n Such distriubuted systems need a component to merge the preliminary results from member instnaces.\n\n\n" +
+            "In this article, we'll call a computer server that works as a member of a cluster an _instance_. " +
+            "for example, as shown in this http://redpen.ignored.url/[mishpelled link], each instance in distributed search engines stores the the fractions of data.\n" +
+            "\nSuch distriubuted systems need a component to merge the preliminary results from member instnaces.\n\n\n" +
             ".Instance image\n" +
             "image::images/tiger.png[Instance image]\n\n" +
             "A sample table:\n\n" +
@@ -74,7 +75,6 @@ var sampleDocuments = {
             "[width=\"60%\",options=\"header\"]\n" +
             "|==============================================\n" +
             "| Option     | Description\n" +
-            "| NAME       | The name of the instance\n" +
             "| GROUP      | The instance group.\n" +
             "|==============================================\n\n" +
             ".example list\n" +
@@ -116,6 +116,7 @@ var sampleDocuments = {
 // ensure the language autodetect doesn't override the user's selection
 var permitLanguageAutoDetect = true;
 
+
 // clear editor and results
 function clearResult() {
     $('#redpen-editor').val('').trigger("input");
@@ -146,7 +147,6 @@ $(document).ready(function () {
         var configSelect = $("#redpen-configuration");
         var languageSelect = $("#redpen-language");
         var documentParserSelect = $("#redpen-document-parser");
-
 
         var editorText = function (newText) {
             if (newText) {
@@ -738,12 +738,13 @@ $(document).ready(function () {
             <div class="col-md-7" id="redpen-document-panel">
                 <div id="redpen-document-top">
                     <div id="redpen-superimposed-editor">
-                        <textarea id="redpen-editor" spellcheck="false"></textarea>
+                        <textarea id="redpen-editor" class="redpen-superimposed-editor-panel"
+                                  spellcheck="false"></textarea>
 
-                        <div id="redpen-editor-underlay"></div>
+                        <pre id="redpen-editor-underlay" class="redpen-superimposed-editor-panel"></pre>
                     </div>
                     <div class="redpen-clear-button">
-                        <button type="button" class="btn btn-sm" onclick="clearResult()">Clear</button>
+                        <button type="button" class="btn btn-xs" onclick="clearResult()" title="Clear text">✕</button>
                     </div>
                 </div>
 


### PR DESCRIPTION
These additions utilize the Ruby parser from the AsciiDoctor project to provide RedPen with basic validation of the none-markup elements of a user's AsciiDoc documents.

It includes updates to the web demo GUI to demonstrate AsciiDoc support.

There is a small issue with offset calculations for the end position of errors when the error is towards the end of an inline element or the end of a sentence, but this issue is caused by how RedPen calculates the end position of errors - we should review that.