### PR TITLE
Output dir in redpen-cli

### DIFF
--- a/redpen-cli/src/main/assembly/executable.xml
+++ b/redpen-cli/src/main/assembly/executable.xml
@@ -2,6 +2,7 @@
     <id>assembled</id>
     <formats>
         <format>tar.gz</format>
+        <format>dir</format>
     </formats>
     <fileSets>
         <fileSet>


### PR DESCRIPTION
This is a hotfix for redpen-distribution package.