### PR TITLE
Implement ProductVersionValidator

### DIFF
--- a/redpen-core/src/main/java/cc/redpen/validator/sentence/ProductVersionValidator.java
+++ b/redpen-core/src/main/java/cc/redpen/validator/sentence/ProductVersionValidator.java
@@ -1,0 +1,62 @@
+package cc.redpen.validator.sentence;
+
+import cc.redpen.model.Sentence;
+import cc.redpen.tokenizer.TokenElement;
+import cc.redpen.validator.Validator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validator to reduce validation error about duplicated period
+ * (for example version number) in sentence.
+ */
+public class ProductVersionValidator extends Validator {
+    private static final Logger LOG = LoggerFactory.getLogger(ProductVersionValidator.class);
+    private static final Pattern PRODUCT_VERSION = Pattern.compile("\\s(\\d*\\.\\d+)(\\.\\d+)?");
+
+    public ProductVersionValidator() {}
+
+    @Override
+    public List<String> getSupportedLanguages() {
+        return Arrays.asList(Locale.JAPANESE.getLanguage());
+    }
+
+    @Override
+    public void validate(Sentence sentence) {
+        String content = sentence.getContent();
+        Matcher matcher = PRODUCT_VERSION.matcher(content);
+        List<TokenElement> tokens = sentence.getTokens();
+        int tokenIndex = 0;
+        while(matcher.find()) {
+            int tokenStartOffset = matcher.start() + 1;
+            String word = content.substring(matcher.start() + 1, matcher.end());
+            tokenIndex = searchTokenIndexByOffset(tokens, tokenStartOffset);
+            List<String> tags = tokens.get(tokenIndex).getTags();
+            TokenElement mergedToken = new TokenElement(word, tags, tokenStartOffset);
+            for (int i = 0; i < word.length(); i++) {
+                tokens.remove(tokenIndex);
+            }
+            tokens.add(tokenIndex, mergedToken);
+        }
+        sentence.setTokens(tokens);
+    }
+
+    private int searchTokenIndexByOffset(List<TokenElement> tokens, int offset) {
+        int index = 0;
+        int i = 0;
+        for (TokenElement token : tokens) {
+            if (token.getOffset() == offset) {
+                index = i;
+                break;
+            }
+            i++;
+        }
+        return index;
+    }
+}

--- a/redpen-core/src/test/java/cc/redpen/validator/sentence/ProductVersionValidatorTest.java
+++ b/redpen-core/src/test/java/cc/redpen/validator/sentence/ProductVersionValidatorTest.java
@@ -1,0 +1,58 @@
+package cc.redpen.validator.sentence;
+
+import cc.redpen.RedPen;
+import cc.redpen.RedPenException;
+import cc.redpen.config.Configuration;
+import cc.redpen.config.ValidatorConfiguration;
+import cc.redpen.model.Document;
+import cc.redpen.tokenizer.TokenElement;
+import cc.redpen.tokenizer.JapaneseTokenizer;
+import cc.redpen.validator.ValidationError;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ProductVersionValidatorTest {
+    @Test
+    public void testProductVersion() throws RedPenException {
+        Configuration config = new Configuration.ConfigurationBuilder()
+                .addValidatorConfig(new ValidatorConfiguration("ProductVersion"))
+                .setLanguage("ja").build();
+
+        List<Document> documents = new ArrayList<>();
+        documents.add(
+                new Document.DocumentBuilder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence("RedPen 1.3.0", 0)
+                .build());
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        List<TokenElement> tokens = documents.get(0).getSection(0).getParagraph(0).getSentence(0).getTokens();
+        Assert.assertEquals(3, tokens.size());
+    }
+
+    @Test
+    public void testProductVersionTwice() throws RedPenException {
+        Configuration config = new Configuration.ConfigurationBuilder()
+                .addValidatorConfig(new ValidatorConfiguration("ProductVersion"))
+                .setLanguage("ja").build();
+
+        List<Document> documents = new ArrayList<>();
+        documents.add(
+                new Document.DocumentBuilder(new JapaneseTokenizer())
+                .addSection(1)
+                .addParagraph()
+                .addSentence("RedPen 0.6 RedPen 1.2", 0)
+                .build());
+
+        RedPen redPen = new RedPen(config);
+        Map<Document, List<ValidationError>> errors = redPen.validate(documents);
+        List<TokenElement> tokens = documents.get(0).getSection(0).getParagraph(0).getSentence(0).getTokens();
+        Assert.assertEquals(7, tokens.size());
+    }
+}


### PR DESCRIPTION
It merges some tokens into one such as product version number
in sentence which is written by Japanese.

Before:
  0.1.0 -> tokenizer -> "0",".","1",".","0"

After:
  0.1.0 -> tokenizer -> with this validator -> "0.1.0"

Using DoubledWordValidator which contains "." in skip list is
a workaround in such a situation, but it is too loose.